### PR TITLE
Create organizers

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -239,3 +239,8 @@ body {
 form.button_to {
   display: inline;
 }
+
+.table-default {
+  .col-expand { width: 100%; }
+  .col-mini { white-space: nowrap; }
+}

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -46,6 +46,22 @@ class PlaylistsController < ApplicationController
     end
   end
 
+  def contents
+    @playlist = Playlist.friendly.find(params[:id])
+  end
+
+  def sort
+    @playlist = Playlist.friendly.find(params[:id])
+    @video = @playlist.videos.find(params[:video])
+    case params[:operation]
+    when 'up'
+      @video.move_higher
+    when 'down'
+      @video.move_lower
+    end
+    redirect_to contents_playlist_path(@playlist)
+  end
+
   private
 
   def playlist_attributes

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -67,6 +67,26 @@ class TopicsController < ApplicationController
     end
   end
 
+  def contents
+    @topic = Topic.friendly.find(params[:id])
+  end
+
+  def sort
+    @topic = Topic.friendly.find(params[:id])
+    @playlist = @topic.playlists.find(params[:playlist])
+    case params[:operation]
+    when 'up'
+      @playlist.move_higher
+    when 'down'
+      @playlist.move_lower
+    when 'unlink'
+      @playlist.remove_from_list
+      @playlist.topic = nil
+    end
+    @playlist.save
+    redirect_to contents_topic_path(@topic)
+  end
+
   private
 
   def topic_attributes

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -12,6 +12,7 @@ class Playlist < ApplicationRecord
 
   has_many :videos, -> { order(position: :asc) }
   belongs_to :topic
+  acts_as_list scope: :topic
   
   def total_length
     videos.map { |v| v.duration }.reduce(0, :+)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -10,5 +10,5 @@ class Topic < ApplicationRecord
   validates_attachment :photo, presence: true, content_type: { content_type: /\Aimage\/.*\Z/ }, size: { in: 0..2.megabytes }
 
   # Playlists can survive without a topic, so on delete set the topic to null.
-  has_many :playlists, dependent: :nullify
+  has_many :playlists, -> { order(position: :asc) }, dependent: :nullify
 end

--- a/app/views/playlists/contents.html.erb
+++ b/app/views/playlists/contents.html.erb
@@ -1,0 +1,34 @@
+<h1><%= link_to @playlist.title, playlist_path(@playlist) %>
+<h2><%= t('.title') %></h2>
+
+<table class="table table-default">
+  <thead>
+    <tr>
+      <th><%= t('.position') %></th>
+      <th><%= t('.episode') %></th>
+      <th colspan="2"><%= t('.operations') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @playlist.videos.each do |video| %>
+    <tr>
+      <td><%= video.position %></td>
+      <td class="col-expand"><%= link_to video.title, playlist_video_path(video, playlist_id: @playlist) %></td>
+      <td class="col-mini">
+        <%= button_to sort_playlist_path(@playlist), class: 'btn btn-default btn-xs', method: :put do %>
+          <%= hidden_field_tag :video, video.id %>
+          <%= hidden_field_tag :operation, :up %>
+          <%= t('.up') %>
+        <% end unless video.first? %>
+      </td>
+      <td class="col-mini">
+        <%= button_to sort_playlist_path(@playlist), class: 'btn btn-default btn-xs', method: :put do %>
+          <%= hidden_field_tag :video, video.id %>
+          <%= hidden_field_tag :operation, :down %>
+          <%= t('.down') %>
+        <% end unless video.last? %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -6,6 +6,7 @@
 <div class="buttons-bar">
 <div class="text-right">
 <%= link_to t('.edit'), edit_playlist_path(@playlist), class: 'btn btn-default' %>
+<%= link_to t('.sort'), contents_playlist_path(@playlist), class: 'btn btn-default' %>
 <%= button_to t('.delete'), playlist_path(@playlist), method: :delete, class: 'btn btn-danger', data: { confirm: t('.really_delete') } %>
 </div>
 </div>

--- a/app/views/topics/contents.html.erb
+++ b/app/views/topics/contents.html.erb
@@ -1,0 +1,41 @@
+<h1><%= link_to @topic.title, topic_path(@topic) %></h1>
+<h2><%= t('.title') %></h2>
+
+<table class="table table-default">
+  <thead>
+    <tr>
+      <th><%= t('.position') %></th>
+      <th><%= t('.title') %></th>
+      <th colspan="3"><%= t('.operations') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @topic.playlists.each do |playlist| %>
+    <tr>
+      <td><%= playlist.position %></td>
+      <td class="col-expand"><%= playlist.title %></td>
+      <td class="col-mini">
+        <%= button_to sort_topic_path(@topic), method: :put, class: 'btn btn-default btn-xs' do %>
+          <%= hidden_field_tag :playlist, playlist.id %>
+          <%= hidden_field_tag :operation, :up %>
+          <%= t('.up') %>
+        <% end unless playlist.first? %>
+      </td>
+      <td class="col-mini">
+        <%= button_to sort_topic_path(@topic), method: :put, class: 'btn btn-default btn-xs' do %>
+          <%= hidden_field_tag :playlist, playlist.id %>
+          <%= hidden_field_tag :operation, :down %>
+          <%= t('.down') %>
+        <% end unless playlist.last? %>
+      </td>
+      <td class="col-mini">
+        <%= button_to sort_topic_path(@topic), method: :put, class: 'btn btn-danger btn-xs' do %>
+          <%= hidden_field_tag :playlist, playlist.id %>
+          <%= hidden_field_tag :operation, :unlink %>
+          <%= t('.unlink') %>
+        <% end %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/topics/contents.html.erb
+++ b/app/views/topics/contents.html.erb
@@ -5,7 +5,7 @@
   <thead>
     <tr>
       <th><%= t('.position') %></th>
-      <th><%= t('.title') %></th>
+      <th><%= t('.playlist') %></th>
       <th colspan="3"><%= t('.operations') %></th>
     </tr>
   </thead>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -10,6 +10,7 @@
 
   <div class="pull-right">
   <%= link_to t('.edit'), edit_topic_path(@topic), class: 'btn btn-default' %>
+  <%= link_to t('.sort'), contents_topic_path(@topic), class: 'btn btn-default' %>
   <%= button_to t('.delete'), topic_path(@topic), method: :delete, class: 'btn btn-danger', data: { confirm: t('.really_delete') } %>
   </div>
 </div>
@@ -29,11 +30,6 @@
             <span class="small">&bull; <%= t('.videos', count: p.videos.length) %></span>
           </h4>
           <p class="list-group-item-text"><%= p.description %></p>
-        </div>
-      </div>
-      <div class="list-group-buttons">
-        <div class="pull-right">
-          <%= button_to t('.remove_list'), release_topic_path(@topic, playlist: p.id), method: :delete, class: 'btn btn-xs btn-danger', data: { confirm: t('.really_remove') } %>
         </div>
       </div>
     <% end %>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -98,14 +98,21 @@ es:
         twitter: Twitter
         youtube: YouTube
   playlists:
+    contents:
+      down: Bajar
+      episode: Episodio
+      operations: Operaciones
+      position: Posición
+      title: Organizar contenidos de la lista
+      up: Subir
+    edit:
+      title: Editar lista de reproducción
     form:
       basic_information: Información básica
       errors: Hay errores que impiden guardar el formulario.
       management: Administración
       save: Guardar
       search: Buscar
-    edit:
-      title: Editar lista de reproducción
     index:
       episode:
         one: 1 episodio
@@ -118,6 +125,7 @@ es:
       delete: Borrar lista
       edit: Editar lista
       really_delete: Esto borrará la lista para siempre. ¿Estás seguro?
+      sort: Organizar lista
   topics:
     form:
       basic_information: Información básica

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -127,6 +127,14 @@ es:
       really_delete: Esto borrará la lista para siempre. ¿Estás seguro?
       sort: Organizar lista
   topics:
+    contents:
+      title: Ordenar listas
+      position: Posición
+      playlist: Lista de reproducción
+      operations: Operaciones
+      up: Subir
+      down: Bajar
+      unlink: Retirar
     form:
       basic_information: Información básica
       errors: Hay errores que impiden guardar el formulario.
@@ -149,6 +157,7 @@ es:
     show:
       delete: Borrar tema
       edit: Editar tema
+      sort: Ordenar listas
       insert_list: Insertar una lista
       really_delete: Esto borrará el tema para siempre. ¿Estás seguro?
       really_remove: "Esto retirará la lista de este tema, sin borrar nada." 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
 
   # These routes should be limited to authorized users.
   resources :playlists, path: 'series', only: [:new, :create, :edit, :update, :destroy] do
+    member do
+      get :contents # Lets the authorized user to organize the playlist contents
+      put :sort # Saves the changes made in :contents
+    end
     resources :videos, path: '/', only: [:edit, :update, :destroy]
   end
   resources :videos, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
       get :insert, to: 'topics#insert'
       post :insert, to: 'topics#do_insert'
       delete :release, to: 'topics#release'
+      get :contents # Lets authorized users to organize topic contents
+      put :sort # Saves changes made in contents
     end
   end
   

--- a/db/migrate/20160917173222_add_position_to_playlist.rb
+++ b/db/migrate/20160917173222_add_position_to_playlist.rb
@@ -1,0 +1,6 @@
+class AddPositionToPlaylist < ActiveRecord::Migration[5.0]
+  def change
+    add_column :playlists, :position, :integer
+    add_index :playlists, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160808112832) do
+ActiveRecord::Schema.define(version: 20160917173222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,8 @@ ActiveRecord::Schema.define(version: 20160808112832) do
     t.integer  "photo_file_size"
     t.datetime "photo_updated_at"
     t.integer  "topic_id"
+    t.integer  "position"
+    t.index ["position"], name: "index_playlists_on_position", using: :btree
     t.index ["slug"], name: "index_playlists_on_slug", unique: true, using: :btree
   end
 

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -202,19 +202,17 @@ RSpec.describe PlaylistsController, type: :controller do
   context 'PUT #sort' do
     before(:each) do
       @playlist = FactoryGirl.create(:playlist)
-      @video1 = FactoryGirl.create(:video, playlist: @playlist)
-      @video2 = FactoryGirl.create(:video, playlist: @playlist, youtube_id: 'asdf')
+      @video1 = FactoryGirl.create(:video, playlist: @playlist, position: 1)
+      @video2 = FactoryGirl.create(:video, playlist: @playlist, youtube_id: 'asdf', position: 2)
     end
 
     it 'should move the video up when requested' do
-      expect(@video2.position).to eq 2 # I don't trust this library.
       put :sort, params: { id: @playlist, video: @video2.id, operation: :up }
       @video2.reload
       expect(@video2.position).to eq 1
     end
 
     it 'should move the video down when requested' do
-      expect(@video1.position).to eq 1 # I don't trust this library.
       put :sort, params: { id: @playlist, video: @video1.id, operation: :down }
       @video1.reload
       expect(@video1.position).to eq 2

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -182,4 +182,47 @@ RSpec.describe PlaylistsController, type: :controller do
       expect(response).to redirect_to playlists_path
     end
   end
+
+  context 'GET #contents' do
+    before(:each) do
+      @playlist = FactoryGirl.create(:playlist)
+    end
+
+    it 'should not fail' do
+      get :contents, params: { id: @playlist }
+      expect(response).to be_success
+    end
+
+    it 'should assign the playlist' do
+      get :contents, params: { id: @playlist }
+      expect(assigns(:playlist)).to eq @playlist
+    end
+  end
+
+  context 'PUT #sort' do
+    before(:each) do
+      @playlist = FactoryGirl.create(:playlist)
+      @video1 = FactoryGirl.create(:video, playlist: @playlist)
+      @video2 = FactoryGirl.create(:video, playlist: @playlist, youtube_id: 'asdf')
+    end
+
+    it 'should move the video up when requested' do
+      expect(@video2.position).to eq 2 # I don't trust this library.
+      put :sort, params: { id: @playlist, video: @video2.id, operation: :up }
+      @video2.reload
+      expect(@video2.position).to eq 1
+    end
+
+    it 'should move the video down when requested' do
+      expect(@video1.position).to eq 1 # I don't trust this library.
+      put :sort, params: { id: @playlist, video: @video1.id, operation: :down }
+      @video1.reload
+      expect(@video1.position).to eq 2
+    end
+
+    it 'should redirect after operation' do
+      put :sort, params: { id: @playlist, video: @video1.id, operation: :down }
+      expect(response).to redirect_to contents_playlist_path(@playlist)
+    end
+  end
 end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -244,4 +244,53 @@ RSpec.describe TopicsController, type: :controller do
       expect(response).to redirect_to topic_path(@topic)
     end
   end
+
+  context 'GET #contents' do
+    before(:each) do
+      @topic = FactoryGirl.create(:topic)
+    end
+
+    it 'should assign the topic' do
+      get :contents, params: { id: @topic }
+      expect(assigns(:topic)).to eq @topic
+    end
+
+    it 'should be success' do
+      get :contents, params: { id: @topic }
+      expect(response).to be_success
+    end
+  end
+
+  context 'PUT #sort' do
+    before(:each) do
+      @topic = FactoryGirl.create(:topic)
+      @playlist1 = FactoryGirl.create(:playlist, topic: @topic, position: 1)
+      @playlist2 = FactoryGirl.create(:playlist, topic: @topic, position: 2)
+    end
+
+    it 'should move the playlist up when requested' do
+      put :sort, params: { id: @topic, playlist: @playlist2.id, operation: :up }
+      @playlist2.reload
+      expect(@playlist2.position).to eq 1
+    end
+
+    it 'should move the playlist down when requested' do
+      put :sort, params: { id: @topic, playlist: @playlist1.id, operation: :down }
+      @playlist1.reload
+      expect(@playlist1.position).to eq 2
+    end
+
+    it 'should unlinke the playlist when requested' do
+      put :sort, params: { id: @topic, playlist: @playlist1.id, operation: :unlink }
+      @playlist1.reload
+      expect(@playlist1.topic).to be nil
+      @playlist2.reload
+      expect(@playlist2.position).to eq 1
+    end
+
+    it 'should redirect to the editor' do
+      put :sort, params: { id: @topic, playlist: @playlist1.id, operation: :up }
+      expect(request).to redirect_to contents_topic_path(@topic)
+    end
+  end
 end

--- a/spec/features/playlists_spec.rb
+++ b/spec/features/playlists_spec.rb
@@ -125,4 +125,63 @@ RSpec.feature "Playlists", type: :feature do
       expect(page).not_to have_content @title
     end
   end
+
+  context 'sorting a playlist' do
+    before(:each) do
+      @playlist = FactoryGirl.create(:playlist)
+      @videos = [
+        FactoryGirl.create(:video, playlist: @playlist,
+          position: 1, title: 'Video A', youtube_id: '1234'),
+        FactoryGirl.create(:video, playlist: @playlist,
+          position: 2, title: 'Video B', youtube_id: '1235')
+      ]
+    end
+
+    it 'is possible to access the sorting page for a playlist' do
+      visit playlist_path(@playlist)
+      expect(page).to have_content I18n.t('playlists.show.sort')
+      click_link I18n.t('playlists.show.sort')
+      expect(page).to have_current_path contents_playlist_path(@playlist)
+    end
+
+    it 'should have a valid view' do
+      visit contents_playlist_path(@playlist)
+      expect(page).to have_http_status :success
+    end
+
+    it 'should list the videos' do
+      visit contents_playlist_path(@playlist)
+      @videos.each { |v| expect(page).to have_content v.title }
+    end
+
+    it 'should be possible to higher the position of a video' do
+      visit contents_playlist_path(@playlist)
+      within find('tr', text: @videos[1].title) do
+        click_button I18n.t('playlists.contents.up')
+      end
+      @videos[1].reload
+      expect(@videos[1].position).to eq 1
+    end
+
+    it 'should be possible to lower the position of a video' do
+      visit contents_playlist_path(@playlist)
+      within find('tr', text: @videos[0].title) do
+        click_button I18n.t('playlists.contents.down')
+      end
+      @videos[0].reload
+      expect(@videos[0].position).to eq 2
+    end
+
+    it 'should not be possible to higher the position of first video' do
+      visit contents_playlist_path(@playlist)
+      row = find('tr', text: @videos[0].title)
+      expect(row).not_to have_content I18n.t('playlists.contents.up')
+    end
+
+    it 'should not be possible to lower the position of last video' do
+      visit contents_playlist_path(@playlist)
+      row = find('tr', text: @videos[1].title)
+      expect(row).not_to have_content I18n.t('playlists.contents.down')
+    end
+  end
 end

--- a/spec/features/topics_spec.rb
+++ b/spec/features/topics_spec.rb
@@ -67,4 +67,72 @@ RSpec.feature "Topics", type: :feature do
       expect(page).to have_select I18n.t('topics.insert.playlist'), options: [@playlist_off.title]
     end
   end
+
+  context 'sorting playlists in a topic' do
+    before(:each) do
+      @topic = FactoryGirl.create(:topic)
+      @playlists = [
+        # Use different names since that can confuse Capybara
+        FactoryGirl.create(:playlist, topic: @topic, position: 1, title: 'Playlist A'),
+        FactoryGirl.create(:playlist, topic: @topic, position: 2, title: 'Playlist B')
+      ]
+    end
+
+    it 'should have a page for sorting contents' do
+      visit topic_path(@topic)
+      expect(page).to have_content I18n.t('topics.show.sort')
+      click_link I18n.t('topics.show.sort')
+    end
+
+    it 'should have a valid view' do
+      visit contents_topic_path(@topic)
+      expect(page).to have_http_status :success
+    end
+
+    it 'should list the playlists in the sorting page' do
+      visit contents_topic_path(@topic)
+      expect(page).to have_content @playlists[0].title
+      expect(page).to have_content @playlists[1].title
+    end
+
+    it 'should be allowed to move a playlist up' do
+      visit contents_topic_path(@topic)
+      within find('tr', text: @playlists[1].title) do
+        click_button I18n.t('topics.contents.up')
+      end
+      @playlists.each { |p| p.reload }
+      expect(@playlists[1].position).to eq 1
+    end
+
+    it 'should be allowed to move a playlist down' do
+      visit contents_topic_path(@topic)
+      within find('tr', text: @playlists[0].title) do
+        click_button I18n.t('topics.contents.down')
+      end
+      @playlists.each { |p| p.reload }
+      expect(@playlists[0].position).to eq 2
+    end
+
+    it 'should be allowed to unlink a playlist' do
+      visit contents_topic_path(@topic)
+      within find('tr', text: @playlists[0].title) do
+        click_button I18n.t('topics.contents.unlink')
+      end
+      @playlists.each { |p| p.reload }
+      expect(@playlists[1].position).to eq 1
+      expect(@playlists[0].topic).to be nil
+    end
+
+    it 'is not possible to move higher the first playlist' do
+      visit contents_topic_path(@topic)
+      row = find('tr', text: @playlists[0].title)
+      expect(row).not_to have_content I18n.t('topics.contents.up')
+    end
+
+    it 'is not possible to move lower the last playlist' do
+      visit contents_topic_path(@topic)
+      row = find('tr', text: @playlists[1].title)
+      expect(row).not_to have_content I18n.t('topics.contents.down')
+    end
+  end
 end

--- a/spec/features/topics_spec.rb
+++ b/spec/features/topics_spec.rb
@@ -67,18 +67,4 @@ RSpec.feature "Topics", type: :feature do
       expect(page).to have_select I18n.t('topics.insert.playlist'), options: [@playlist_off.title]
     end
   end
-
-  context 'removing a playlist from a topic' do
-    before(:each) do
-      @topic = FactoryGirl.create(:topic)
-      @playlist = FactoryGirl.create(:playlist, topic: @topic)
-    end
-
-    it 'should have a valid workflow' do
-      visit topic_path(@topic)
-      click_button I18n.t('topics.show.remove_list')
-      expect(page).to have_content @topic.title
-      expect(page).not_to have_content @playlist.title
-    end
-  end
 end


### PR DESCRIPTION
Things can now be added to things. Videos can be added to playlists and playlists can be added to topics. However, how can things be sorted? It should be possible to sort videos in a playlist if they are added wrong. Similarly, it would be nice to have playlists sorted in a topic and the administrator should be able to move playlists up and down.