### PR TITLE
Allow to hide videos from the featured box

### DIFF
--- a/app/controllers/dashboard/videos_controller.rb
+++ b/app/controllers/dashboard/videos_controller.rb
@@ -54,7 +54,7 @@ class Dashboard::VideosController < Dashboard::DashboardController
   end
 
   def video_params
-    params.require(:video).permit(:title, :description, :youtube_id, :duration, :playlist_id, :created_at)
+    params.require(:video).permit(:title, :description, :youtube_id, :duration, :playlist_id, :unfeatured, :created_at)
   end
 
 end

--- a/app/controllers/front_controller.rb
+++ b/app/controllers/front_controller.rb
@@ -1,6 +1,6 @@
 class FrontController < ApplicationController
   def index
     @opinions = Opinion.limit(4)
-    @recent = Video.order(created_at: :desc).limit(4)
+    @recent = Video.where(unfeatured: false).order(created_at: :desc).limit(4)
   end
 end

--- a/app/views/dashboard/videos/_form.html.erb
+++ b/app/views/dashboard/videos/_form.html.erb
@@ -9,7 +9,8 @@
     <%= number_field_tag 'duration[minutes]', (((@video.duration % 3600) / 60) rescue 0), class: 'form-control', min: 0, max: 59 %> :
     <%= number_field_tag 'duration[seconds]', ((@video.duration % 60) rescue 0), class: 'form-control', min: 0, max: 59 %>
     </p>
-  <% end %>
+  <% end %>  
   <%= form.association :playlist, include_blank: :translate %>
+  <%= form.input :unfeatured %>
   <%= form.submit class: 'btn btn-success' %>
 <% end %>

--- a/config/locales/model.es.yml
+++ b/config/locales/model.es.yml
@@ -45,7 +45,11 @@ es:
         thumbnail: Miniatura
         playlist: Lista de reproducción
         youtube_id: ID de YouTube
+        unfeatured: No destacar
   simple_form:
     include_blanks:
       playlist:
         topic: (Sin tema concreto)
+    labels:
+      video:
+        unfeatured: No destacar este vídeo en la página principal.

--- a/db/migrate/20170219113217_add_unfeatured_to_videos.rb
+++ b/db/migrate/20170219113217_add_unfeatured_to_videos.rb
@@ -1,0 +1,5 @@
+class AddUnfeaturedToVideos < ActiveRecord::Migration[5.0]
+  def change
+    add_column :videos, :unfeatured, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170213185405) do
+ActiveRecord::Schema.define(version: 20170219113217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,15 +80,16 @@ ActiveRecord::Schema.define(version: 20170213185405) do
   end
 
   create_table "videos", force: :cascade do |t|
-    t.string   "title",       null: false
-    t.text     "description", null: false
-    t.string   "youtube_id",  null: false
-    t.integer  "duration",    null: false
-    t.string   "slug",        null: false
-    t.integer  "playlist_id", null: false
-    t.integer  "position",    null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.string   "title",                       null: false
+    t.text     "description",                 null: false
+    t.string   "youtube_id",                  null: false
+    t.integer  "duration",                    null: false
+    t.string   "slug",                        null: false
+    t.integer  "playlist_id",                 null: false
+    t.integer  "position",                    null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.boolean  "unfeatured",  default: false, null: false
     t.index ["slug"], name: "index_videos_on_slug", using: :btree
     t.index ["youtube_id"], name: "index_videos_on_youtube_id", unique: true, using: :btree
   end

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -41,6 +41,30 @@ RSpec.feature "Dashboard videos", type: :feature do
       expect(@playlist.videos.count).to eq 1
     end
 
+    scenario "user can create unfeatured videos" do
+      @playlist = FactoryGirl.create(:playlist)
+      visit dashboard_videos_path
+
+      expect {
+        click_link 'Nuevo Vídeo'
+        fill_in 'Título', with: 'My video title'
+        fill_in 'Descripción', with: 'This is my newest and coolest video'
+        fill_in 'ID de YouTube', with: 'dQw4w9WgXcQ'
+        # TODO: Should test the actual interaction with duration controls.
+        # (They require JavaScript and I'll prefer to finish this test suite
+        # before adding extra dependencies that could break existing tests)
+        find(:xpath, "//input[@id='video_duration']", visible: false).set '212'
+        select @playlist.title, from: 'Lista de reproducción'
+        check 'video_unfeatured'
+        click_button 'Crear Vídeo'
+      }.to change { Video.count }.by 1
+
+      visit root_path
+      within '.recent-videos' do
+        expect(page).not_to have_link 'My video title'
+      end
+    end
+
     scenario "user cannot create videos with invalid data" do
       @playlist = FactoryGirl.create(:playlist)
       visit dashboard_videos_path

--- a/spec/features/front/front_page_spec.rb
+++ b/spec/features/front/front_page_spec.rb
@@ -43,12 +43,24 @@ RSpec.feature "Front page", type: :feature do
 
     it "shows the video thumbnail" do
       visit root_path
-      expect(page).to have_css "img[src='https://i1.ytimg.com/vi/#{@video.youtube_id}/mqdefault.jpg']"
+      within '.recent-videos' do
+        expect(page).to have_css "img[src='https://i1.ytimg.com/vi/#{@video.youtube_id}/mqdefault.jpg']"
+      end
     end
 
     it "links to the video" do
       visit root_path
-      expect(page).to have_link @video.title, href: playlist_video_path(@video, playlist_id: @video.playlist)
+      within '.recent-videos' do
+        expect(page).to have_link @video.title, href: playlist_video_path(@video, playlist_id: @video.playlist)
+      end
+    end
+
+    it "doesn't show videos hidden from front" do
+      @hidden = FactoryGirl.create(:video, title: 'Hidden', youtube_id: 'AABBCC', unfeatured: true)
+      within('.recent-videos') do
+        expect(page).to have_link @video.title
+        expect(page).not_to have_link @hidden.title
+      end
     end
   end
 end

--- a/spec/features/front/front_page_spec.rb
+++ b/spec/features/front/front_page_spec.rb
@@ -57,7 +57,8 @@ RSpec.feature "Front page", type: :feature do
 
     it "doesn't show videos hidden from front" do
       @hidden = FactoryGirl.create(:video, title: 'Hidden', youtube_id: 'AABBCC', unfeatured: true)
-      within('.recent-videos') do
+      visit root_path
+      within '.recent-videos' do
         expect(page).to have_link @video.title
         expect(page).not_to have_link @hidden.title
       end


### PR DESCRIPTION
Applying this patch will add a checkbox to the video form editor. Activating this checkbox when saving a video will force that video not to be displayed in the featured box in the front page even if the video is recent.

![image](https://cloud.githubusercontent.com/assets/1568690/23101974/9c0c9e98-f6a0-11e6-8bb7-fd9a2d6d9a27.png)