### PR TITLE
Add publishing date to videos

### DIFF
--- a/app/controllers/dashboard/videos_controller.rb
+++ b/app/controllers/dashboard/videos_controller.rb
@@ -54,7 +54,7 @@ class Dashboard::VideosController < Dashboard::DashboardController
   end
 
   def video_params
-    params.require(:video).permit(:title, :description, :youtube_id, :duration, :playlist_id, :unfeatured, :created_at)
+    params.require(:video).permit(:title, :description, :youtube_id, :duration, :playlist_id, :unfeatured, :published_at)
   end
 
 end

--- a/app/controllers/front_controller.rb
+++ b/app/controllers/front_controller.rb
@@ -1,6 +1,6 @@
 class FrontController < ApplicationController
   def index
     @opinions = Opinion.limit(4)
-    @recent = Video.where(unfeatured: false).order(created_at: :desc).limit(4)
+    @recent = Video.visible.where(unfeatured: false).order(created_at: :desc).limit(4)
   end
 end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -14,7 +14,7 @@ class VideosController < ApplicationController
   def show
     @playlist = Playlist.friendly.find(params[:playlist_id])
     @video = @playlist.videos.friendly.find(params[:id])
+    authenticate_user! if @video.scheduled?
     @in_playlist = @video.higher_items(5) + [@video] + @video.lower_items(5)
   end
-  
 end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,7 +1,7 @@
 class VideosController < ApplicationController
 
   def index
-    @videos = Video.joins(:playlist).all
+    @videos = Video.visible.joins(:playlist).all
     if params[:length]
       @videos = @videos.where('duration <= 300') if params[:length] == "short"
       @videos = @videos.where('duration > 300 and duration <= 900') if params[:length] == "medium"

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -14,6 +14,7 @@ class Video < ApplicationRecord
   validates :youtube_id, presence: true, length: { maximum: 15 }
   validates :duration, presence: true, numericality: { greater_than: 0 }
   validates :playlist, presence: true
+  validates :published_at, presence: true
 
   # Natural duration
   def natural_duration= dur

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -8,6 +8,9 @@ class Video < ApplicationRecord
   # Slug. Can be repeated as long as it's on different playlists.
   friendly_id :title, use: [:slugged, :scoped], scope: :playlist
 
+  # Scope for limiting the amount of videos to those actually published.
+  scope :visible, -> { where('published_at <= ?', DateTime.now) }
+
   # Validations.
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, presence: true, length: { maximum: 1500 }
@@ -27,7 +30,22 @@ class Video < ApplicationRecord
     end
   end
 
+  # Visible videos are those whose publication date has been already reached.
+  # Therefore this videos are visible on lists, playlists, searches...
+  def visible?
+    self.published_at <= DateTime.now
+  end
+
+  # Scheduled videos are those whose publication date has not been reached yet.
+  # Showing content for this video would spoil the experience and therefore
+  # they should be excluded from searches, lists, playlists...
+  def scheduled?
+    self.published_at > DateTime.now
+  end
+
   def to_s
     title
   end
+
+
 end

--- a/app/views/dashboard/videos/_form.html.erb
+++ b/app/views/dashboard/videos/_form.html.erb
@@ -9,8 +9,9 @@
     <%= number_field_tag 'duration[minutes]', (((@video.duration % 3600) / 60) rescue 0), class: 'form-control', min: 0, max: 59 %> :
     <%= number_field_tag 'duration[seconds]', ((@video.duration % 60) rescue 0), class: 'form-control', min: 0, max: 59 %>
     </p>
-  <% end %>  
+  <% end %>
   <%= form.association :playlist, include_blank: :translate %>
+  <%= form.input :published_at %>
   <%= form.input :unfeatured %>
   <%= form.submit class: 'btn btn-success' %>
 <% end %>

--- a/app/views/dashboard/videos/index.html.erb
+++ b/app/views/dashboard/videos/index.html.erb
@@ -16,6 +16,7 @@
       <th><%= t('.title') %></th>
       <th><%= t('.playlist') %></th>
       <th><%= t('.release_date') %></th>
+      <th><%= t('.last_update') %></th>
       <th><%= t('.operations') %></th>
     </tr>
   </thead>
@@ -24,7 +25,8 @@
     <tr>
       <td><%= link_to video.title, [:dashboard, video] %></td>
       <td><%= link_to video.playlist.title, [:dashboard, video.playlist] %></td>
-      <td><%= video.created_at %></td>
+      <td><%= l video.published_at, format: :long %></td>
+      <td><%= distance_of_time_in_words video.updated_at, DateTime.now %></td>
       <td>
         <%= link_to t('.edit'), [:edit, :dashboard, video], class: 'btn btn-xs btn-default' %>
         <%= button_to t('.destroy'), [:dashboard, video], method: :delete, class: 'btn btn-xs btn-danger', data: { confirm: t('.really_destroy') } %>

--- a/app/views/dashboard/videos/show.html.erb
+++ b/app/views/dashboard/videos/show.html.erb
@@ -33,4 +33,8 @@
     <td><%= t('.playlist') %></td>
     <td><%= link_to @video.playlist.title, [:dashboard, @video.playlist] %></td>
   </tr>
+  <tr>
+    <td><%= t('.published_at') %></td>
+    <td><%= l @video.published_at %></td>
+  </tr>
 </table>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -5,6 +5,7 @@
 <title><%= content_for?(:title) ? content_for(:title) : "makigas" %></title>
 <%= tag(:meta, name: 'description', content: content_for(:description)) if content_for?(:description) %>
 <%= tag(:link, rel: 'canonical', href: canonical_url) %>
+<%= content_for(:meta) if content_for?(:meta) -%>
 <%= content_for(:twitter) -%>
 <%= content_for(:facebook) -%>
 

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -10,7 +10,7 @@
 <div class="col-xs-6 col-sm-4 col-lg-3">
 <%= link_to pl do %>
 <div class="playlist panel panel-default">
-  <span class="badge"><%= t('.episode', count: pl.videos.count) %></span>
+  <span class="badge"><%= t('.episode', count: pl.videos.visible.count) %></span>
   <%= image_tag pl.thumbnail.url(:default), srcset: "#{pl.thumbnail.url(:hidef)} 2x" %>
   <div class="panel-heading">
     <h3 class="panel-title"><%= pl.title %></h3>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -39,7 +39,7 @@
 <div class="row">
 <div class="col-md-8 col-md-offset-2">
   <div class="episodes-table list-group">
-  <% @playlist.videos.each do |v| %>
+  <% @playlist.videos.visible.each do |v| %>
     <%= link_to playlist_video_path(v, playlist_id: @playlist), class: 'list-group-item' do %>
       <div class="badge video-duration"><%= running_time(v.duration) %></div>
       <h4 class="list-group-item-heading"><%= v.position %>. <%= v.title %></h4>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -39,7 +39,7 @@
 <div class="col-xs-6 col-sm-4 col-lg-3">
 <%= link_to pl do %>
 <div class="playlist panel panel-default">
-  <span class="badge"><%= t('.episode', count: pl.videos.count) %></span>
+  <span class="badge"><%= t('.episode', count: pl.videos.visible.count) %></span>
   <%= image_tag pl.thumbnail.url(:default), srcset: "#{pl.thumbnail.url(:hidef)} 2x" %>
   <div class="panel-heading">
     <h3 class="panel-title"><%= pl.title %></h3>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -15,6 +15,11 @@
 <meta property="og:site_name" content="makigas">
 <meta property="og:image" content="<%= image_url(@video.playlist.card.url, only_path: false) %>">
 <% end %>
+<% content_for :meta do %>
+  <% if @video.scheduled? %>
+  <meta name="robots" content="noindex">
+  <% end %>
+<% end %>
 <% content_for :body_classes, 'video-player-page' %>
 
 <% if @video.playlist.topic %>
@@ -45,7 +50,7 @@
   <% else %>
   <%= link_to t('.previous'), '#', disabled: true, class: 'disabled pull-left btn btn-default' %>
   <% end %>
-  
+
   <% unless @video.last? %>
   <%= link_to t('.next'), playlist_video_path(@video.lower_item, playlist_id: @playlist), class: 'pull-right btn btn-default' %>
   <% else %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -61,7 +61,7 @@
       <div class="col-md-7">
         <%= to_markdown @video.description %>
         <p>
-          <%= t('.release_date_html', date: content_tag(:time, l(@video.created_at, format: :short), datetime: @video.created_at.to_time.iso8601)) %> &bull;
+          <%= t('.release_date_html', date: content_tag(:time, l(@video.published_at.to_date, format: :long), datetime: @video.published_at.to_time.iso8601)) %> &bull;
           <%= t('.duration', duration: running_time(@video.duration)) %>
         </p>
 

--- a/config/locales/dashboard.es.yml
+++ b/config/locales/dashboard.es.yml
@@ -206,6 +206,7 @@ es:
         dashboard: Panel de control
         destroy: Destruir
         edit: Editar
+        last_update: Última modificación
         new_video: Nuevo Vídeo
         operations: Operaciones
         playlist: Lista

--- a/config/locales/model.es.yml
+++ b/config/locales/model.es.yml
@@ -44,6 +44,7 @@ es:
         slug: URL
         thumbnail: Miniatura
         playlist: Lista de reproducción
+        published_at: Fecha de publicación
         youtube_id: ID de YouTube
         unfeatured: No destacar
   simple_form:

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -12,7 +12,7 @@ SitemapGenerator::Sitemap.create do
   add playlists_path, priority: 0.9, changefreq: 'daily'
   Playlist.find_each do |playlist|
     add playlist_path(playlist), priority: 0.8, changefreq: 'weekly'
-    playlist.videos.find_each do |video|
+    playlist.videos.visible.find_each do |video|
       add playlist_video_path(video, playlist_id: playlist), priority: 0.8
     end
   end

--- a/db/migrate/20170227184939_add_published_at_to_videos.rb
+++ b/db/migrate/20170227184939_add_published_at_to_videos.rb
@@ -1,0 +1,18 @@
+class AddPublishedAtToVideos < ActiveRecord::Migration[5.0]
+  def self.up
+    # First, add this column as nullable.
+    add_column :videos, :published_at, :datetime, null: true
+
+    # Fill the value for every video.
+    Video.find_each do |video|
+      video.update_columns(published_at: video.created_at)
+    end
+
+    # Make the column not nullable then.
+    change_column :videos, :published_at, :datetime, null: false
+  end
+
+  def self.down
+    remove_column :videos, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20170227184939) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.integer  "topic_id"
+    t.integer  "position"
     t.string   "thumbnail_file_name"
     t.string   "thumbnail_content_type"
     t.integer  "thumbnail_file_size"
@@ -43,6 +44,7 @@ ActiveRecord::Schema.define(version: 20170227184939) do
     t.string   "card_content_type"
     t.integer  "card_file_size"
     t.datetime "card_updated_at"
+    t.index ["position"], name: "index_playlists_on_position", using: :btree
     t.index ["slug"], name: "index_playlists_on_slug", unique: true, using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170219113217) do
+ActiveRecord::Schema.define(version: 20170227184939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,6 @@ ActiveRecord::Schema.define(version: 20170219113217) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.integer  "topic_id"
-    t.integer  "position"
     t.string   "thumbnail_file_name"
     t.string   "thumbnail_content_type"
     t.integer  "thumbnail_file_size"
@@ -44,7 +43,6 @@ ActiveRecord::Schema.define(version: 20170219113217) do
     t.string   "card_content_type"
     t.integer  "card_file_size"
     t.datetime "card_updated_at"
-    t.index ["position"], name: "index_playlists_on_position", using: :btree
     t.index ["slug"], name: "index_playlists_on_slug", unique: true, using: :btree
   end
 
@@ -80,16 +78,17 @@ ActiveRecord::Schema.define(version: 20170219113217) do
   end
 
   create_table "videos", force: :cascade do |t|
-    t.string   "title",                       null: false
-    t.text     "description",                 null: false
-    t.string   "youtube_id",                  null: false
-    t.integer  "duration",                    null: false
-    t.string   "slug",                        null: false
-    t.integer  "playlist_id",                 null: false
-    t.integer  "position",                    null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.boolean  "unfeatured",  default: false, null: false
+    t.string   "title",                        null: false
+    t.text     "description",                  null: false
+    t.string   "youtube_id",                   null: false
+    t.integer  "duration",                     null: false
+    t.string   "slug",                         null: false
+    t.integer  "playlist_id",                  null: false
+    t.integer  "position",                     null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.boolean  "unfeatured",   default: false, null: false
+    t.datetime "published_at",                 null: false
     t.index ["slug"], name: "index_videos_on_slug", using: :btree
     t.index ["youtube_id"], name: "index_videos_on_youtube_id", unique: true, using: :btree
   end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -6,5 +6,17 @@ FactoryGirl.define do
     duration 232
     association :playlist, factory: :playlist
     position 1
+    published_at { DateTime.now }
+
+    trait :published_yesterday do
+      published_at { 1.day.ago }
+    end
+
+    trait :published_tomorrow do
+      published_at { 1.day.from_now }
+    end
+
+    factory :yesterday_video, traits: [:published_yesterday]
+    factory :tomorrow_video, traits: [:published_tomorrow]
   end
 end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     youtube_id '2vjPBrBU-TM'
     duration 232
     association :playlist, factory: :playlist
-    position 1
     published_at { DateTime.now }
 
     trait :published_yesterday do

--- a/spec/features/front/front_opinions_spec.rb
+++ b/spec/features/front/front_opinions_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature 'Front opinions', type: :feature do
+  let!(:opinion) { FactoryGirl.create(:opinion) }
+
+  scenario 'displays link' do
+    visit root_path
+    within('.about-opinions') do
+      expect(page).to have_link opinion.from, href: opinion.url
+    end
+  end
+
+  scenario 'displays description' do
+    visit root_path
+    within('.about-opinions') do
+      expect(page).to have_text opinion.message
+    end
+  end
+
+  scenario 'may not have a link' do
+    opinion.update_attributes(url: nil)
+    visit root_path
+    within('.about-opinions') do
+      expect(page).to have_text opinion.from
+    end
+  end
+end

--- a/spec/features/front/front_page_spec.rb
+++ b/spec/features/front/front_page_spec.rb
@@ -1,67 +1,19 @@
 require 'rails_helper'
 
 RSpec.feature "Front page", type: :feature do
-  it "is success" do
+  scenario "loads successfully" do
     visit root_path
     expect(page.status_code).to be 200
   end
 
-  it "presents the project" do
+  scenario "presents the project" do
     visit root_path
     expect(page).to have_text "¿Qué es makigas?"
   end
 
-  context "can show opinions" do
-    it "with link" do
-      @opinion = FactoryGirl.create(:opinion)
-      visit root_path
-      expect(page).to have_link @opinion.from, href: @opinion.url
-    end
-
-    it "without link" do
-      @opinion = FactoryGirl.create(:opinion, url: nil)
-      visit root_path
-      expect(page).to have_text @opinion.from
-    end
-
-    it "with description" do
-      @opinion = FactoryGirl.create(:opinion)
-      visit root_path
-      expect(page).to have_text @opinion.message
-    end
-  end
-
-  it "navigates to topics" do
+  scenario "allows the user to navigate for topics" do
     visit root_path
-    expect(page).to have_link "Explora las temáticas", href: topics_path
-  end
-
-  context "when there are videos" do
-    before(:each) {
-      @video = FactoryGirl.create(:video)
-    }
-
-    it "shows the video thumbnail" do
-      visit root_path
-      within '.recent-videos' do
-        expect(page).to have_css "img[src='https://i1.ytimg.com/vi/#{@video.youtube_id}/mqdefault.jpg']"
-      end
-    end
-
-    it "links to the video" do
-      visit root_path
-      within '.recent-videos' do
-        expect(page).to have_link @video.title, href: playlist_video_path(@video, playlist_id: @video.playlist)
-      end
-    end
-
-    it "doesn't show videos hidden from front" do
-      @hidden = FactoryGirl.create(:video, title: 'Hidden', youtube_id: 'AABBCC', unfeatured: true)
-      visit root_path
-      within '.recent-videos' do
-        expect(page).to have_link @video.title
-        expect(page).not_to have_link @hidden.title
-      end
-    end
+    click_link 'Explora las temáticas'
+    expect(current_path).to eq topics_path
   end
 end

--- a/spec/features/front/front_videos_spec.rb
+++ b/spec/features/front/front_videos_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature "Videos listed in front page", type: :feature do
+  let!(:video) { FactoryGirl.create(:video) }
+
+  scenario 'displays thumbnail' do
+      visit root_path
+      within '.recent-videos' do
+        expect(page).to have_css "img[src='https://i1.ytimg.com/vi/#{video.youtube_id}/mqdefault.jpg']"
+      end
+  end
+
+  scenario "links to the video" do
+    visit root_path
+    within '.recent-videos' do
+      expect(page).to have_link video.title, href: playlist_video_path(video, playlist_id: video.playlist)
+    end
+  end
+
+  scenario "doesn't show videos hidden from front" do
+    hidden = FactoryGirl.create(:video, title: 'Hidden', youtube_id: 'AABBCC', unfeatured: true)
+    visit root_path
+    within '.recent-videos' do
+      expect(page).to have_link video.title
+      expect(page).not_to have_link hidden.title
+    end
+  end
+
+  scenario "doesn't show videos not yet published" do
+    scheduled = FactoryGirl.create(:tomorrow_video, youtube_id: 'TOMORROW', title: 'Scheduled one')
+    published = FactoryGirl.create(:yesterday_video, youtube_id: 'YESTERDAY', title: 'This is published')
+    
+    visit root_path
+    within '.recent-videos' do
+      expect(page).to have_link published.title
+      expect(page).not_to have_link scheduled.title
+    end
+  end
+end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Video, type: :model do
-  
+
   context 'is valid when instanciated via' do
     it ':video factory' do
       video = FactoryGirl.build(:video)
@@ -69,7 +69,7 @@ RSpec.describe Video, type: :model do
       video = FactoryGirl.build(:video, playlist: nil)
       expect(video).not_to be_valid
     end
-    
+
     it 'is not valid without a publishing date' do
       video = FactoryGirl.build(:video, published_at: nil)
       expect(video).not_to be_valid
@@ -101,7 +101,7 @@ RSpec.describe Video, type: :model do
   end
 
   context 'natural duration' do
-    it 'should convert from duration to natural duration' do 
+    it 'should convert from duration to natural duration' do
       expect(FactoryGirl.build(:video, duration: 12).natural_duration).
         to eq '00:00:12'
       expect(FactoryGirl.build(:video, duration: 61).natural_duration).

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Video, type: :model do
-
   context 'is valid when instanciated via' do
     it ':video factory' do
       video = FactoryGirl.build(:video)
@@ -128,6 +127,53 @@ RSpec.describe Video, type: :model do
       expect(video.duration).to eq 35999
       video.natural_duration = '10:00:00'
       expect(video.duration).to eq 36000
+    end
+  end
+
+  describe '.visible?' do
+    let(:published) { FactoryGirl.build(:video, published_at: 2.days.ago) }
+    let(:scheduled) { FactoryGirl.build(:video, published_at: 6.weeks.from_now) }
+
+    context 'when publishing date has been reached' do
+      subject { published.visible? }
+      it { is_expected.to eq true }
+    end
+
+    context 'when publishing date has not been reached' do
+      subject { scheduled.visible? }
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '.scheduled?' do
+    let(:published) { FactoryGirl.build(:video, published_at: 2.days.ago) }
+    let(:scheduled) { FactoryGirl.build(:video, published_at: 6.weeks.from_now) }
+
+    context 'when publishing date has been reached' do
+      subject { published.scheduled? }
+      it { is_expected.to eq false }
+    end
+
+    context 'when publishing date has not been reached' do
+      subject { scheduled.scheduled? }
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe '.visible' do
+    before(:each) do
+      @published = FactoryGirl.create(:video, youtube_id: 'ASDF', published_at: 2.days.ago)
+      @scheduled = FactoryGirl.create(:video, youtube_id: 'ASDQ', published_at: 2.days.from_now)
+    end
+
+    it 'should contain a video published yesterday' do
+      videos = Video.visible.collect
+      expect(videos).to include @published
+    end
+
+    it 'should not contain a video published tomorrow' do
+      videos = Video.visible.collect
+      expect(videos).not_to include @scheduled
     end
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -2,9 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Video, type: :model do
   
-  it 'has a valid factory' do
-    video = FactoryGirl.build(:video)
-    expect(video).to be_valid
+  context 'is valid when instanciated via' do
+    it ':video factory' do
+      video = FactoryGirl.build(:video)
+      expect(video).to be_valid
+    end
+
+    it ':yesterday_video factory' do
+      video = FactoryGirl.build(:yesterday_video)
+      expect(video).to be_valid
+    end
+
+    it ':tomorrow_video factory' do
+      video = FactoryGirl.build(:tomorrow_video)
+      expect(video).to be_valid
+    end
   end
 
   context 'validation' do
@@ -55,6 +67,11 @@ RSpec.describe Video, type: :model do
 
     it 'is not valid without being in a playlist' do
       video = FactoryGirl.build(:video, playlist: nil)
+      expect(video).not_to be_valid
+    end
+    
+    it 'is not valid without a publishing date' do
+      video = FactoryGirl.build(:video, published_at: nil)
       expect(video).not_to be_valid
     end
 


### PR DESCRIPTION
This pull request coordinates the patch for having a publishing date field integrated into Videos, why is neccesary, and which use cases and user stories it has to be valid for in order to be integrated.

## Tasks

- [x] Add a publishing date field into Video (#19).
- [x] Stop using `created_at` for publishing date and move it to publishing date.
- [x] Add a publishing date field into the video editor.

## Requirements

- [x] Videos whose publishing date is greater than now, should be hidden from the system unless the user has logged in.