### PR TITLE
Allows scheduled videos to be browsed anonymously

### DIFF
--- a/app/assets/stylesheets/videos.scss
+++ b/app/assets/stylesheets/videos.scss
@@ -41,6 +41,12 @@
 }
 
 body.video-player-page {
+  .hero-tron .alert {
+    font-size: 14px;
+    text-align: left;
+    line-height: 1.3;
+  }
+
   @media screen and (max-width: 767px) {
     .hero-tron {
       margin-bottom: 0;

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -14,7 +14,7 @@ class VideosController < ApplicationController
   def show
     @playlist = Playlist.friendly.find(params[:playlist_id])
     @video = @playlist.videos.friendly.find(params[:id])
-    authenticate_user! if @video.scheduled?
+    authenticate_user! if @video.scheduled? && @video.private
     @in_playlist = @video.higher_items(5) + [@video] + @video.lower_items(5)
   end
 end

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -33,6 +33,8 @@
 <%= content_for :hero do %>
   <h1><%= @video.position %>. <%= @video.title %></h1>
   <p><%= t('.part_of_series_html', playlist: link_to(@video.playlist.title, playlist_path(@video.playlist))) %></p>
+
+  <p class="alert alert-warning"><strong><%= t('.preview') %></strong> <%= t('.unlisted') %></p>
 <% end %>
 
 <div class="row video-player">

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -143,6 +143,8 @@ es:
       watch_on_youtube: Ver en YouTube
       release_date_html: "Fecha de emisión: %{date}"
       duration: "Duración: %{duration}"
+      preview: Esto es una vista previa de un vídeo que próximamente estará en YouTube (imagino).
+      unlisted: Este vídeo está sin listar y por ello no lo encontrarás ni en el canal de YouTube ni en las listas de esta web, en este momento.
       explore_other_videos:
         one: Explora el resto de vídeos de esta lista de reproducción.
         other: Una lista de reproducción de %{count} episodios.

--- a/db/migrate/20170417204245_add_private_to_videos.rb
+++ b/db/migrate/20170417204245_add_private_to_videos.rb
@@ -1,0 +1,5 @@
+class AddPrivateToVideos < ActiveRecord::Migration[5.0]
+  def change
+    add_column :videos, :private, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170227184939) do
+ActiveRecord::Schema.define(version: 20170417204245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,6 @@ ActiveRecord::Schema.define(version: 20170227184939) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.integer  "topic_id"
-    t.integer  "position"
     t.string   "thumbnail_file_name"
     t.string   "thumbnail_content_type"
     t.integer  "thumbnail_file_size"
@@ -44,7 +43,6 @@ ActiveRecord::Schema.define(version: 20170227184939) do
     t.string   "card_content_type"
     t.integer  "card_file_size"
     t.datetime "card_updated_at"
-    t.index ["position"], name: "index_playlists_on_position", using: :btree
     t.index ["slug"], name: "index_playlists_on_slug", unique: true, using: :btree
   end
 
@@ -91,6 +89,7 @@ ActiveRecord::Schema.define(version: 20170227184939) do
     t.datetime "updated_at",                   null: false
     t.boolean  "unfeatured",   default: false, null: false
     t.datetime "published_at",                 null: false
+    t.boolean  "private",      default: false, null: false
     t.index ["slug"], name: "index_videos_on_slug", using: :btree
     t.index ["youtube_id"], name: "index_videos_on_youtube_id", unique: true, using: :btree
   end

--- a/spec/features/videos/video_page_spec.rb
+++ b/spec/features/videos/video_page_spec.rb
@@ -45,8 +45,59 @@ RSpec.feature "Video page", type: :feature do
     end
   end
 
-  context 'video is scheduled' do
+  context 'video is scheduled but not private' do
     before { @video.update_attributes(published_at: 2.days.from_now) }
+
+    scenario 'there is information about the video' do
+      visit_video @video
+      expect(page).to have_text @video.title
+      expect(page).to have_content @video.description
+      expect(page).to have_link @video.playlist.title, href: playlist_path(@video.playlist)
+    end
+
+    scenario 'the page is marked as scheduled' do
+      visit_video @video
+      expect(page).to have_text 'Esto es una vista previa de un vídeo que próximamente estará en YouTube (imagino).'
+    end
+
+    scenario 'the page is NOT indexable' do
+      visit_video @video
+      expect(page).to have_css 'meta[name="robots"][content="noindex"]', visible: false
+    end
+
+    scenario 'there is a player embedded in' do
+      visit_video @video
+
+      expect(page).to have_css "iframe[src*='www.youtube-nocookie.com/embed/#{@video.youtube_id}']"
+    end
+
+    scenario 'there is a playlist card' do
+      visit_video @video
+      within("//div[@class='video-information']") do
+        expect(page).to have_content @video.playlist.title
+        expect(page).to have_css "img[src*='#{@video.playlist.thumbnail.url(:small)}']"
+      end
+    end
+
+    context 'a topic has been assigned' do
+      before do
+        @topic = FactoryGirl.create(:topic)
+        @video.playlist.update_attributes(topic: @topic)
+      end
+
+      scenario 'there is a topic card' do
+        visit_video @video
+        within("//div[@class='video-information']") do
+          expect(page).to have_content @topic.title
+          expect(page).to have_content @topic.description
+          expect(page).to have_css "img[src*='#{@topic.thumbnail.url(:small)}']"
+        end
+      end
+    end
+  end
+
+  context 'video is scheduled and private' do
+    before { @video.update_attributes(published_at: 2.days.from_now, private: true) }
 
     scenario 'the page requires authorization' do
       visit_video @video


### PR DESCRIPTION
Apply this commit to add a field to the videos model allowing an admin
to mark a video as private. Private videos only have effect when they
are scheduled.

The old behaviour was, not to let anonymous users to view scheduled
videos. However, now they can be viewed unless this checkbox is marked.
Note that there is no checkbox at the moment. It has to be added.