### PR TITLE
Hide the toolbar on unlisted videos and show the unlisted alert there

### DIFF
--- a/app/assets/stylesheets/videos.scss
+++ b/app/assets/stylesheets/videos.scss
@@ -36,17 +36,15 @@
   }
 }
 
+.alert {
+  margin-top: 15px;
+}
+
 #videos_filter {
   margin-bottom: 1em;
 }
 
 body.video-player-page {
-  .hero-tron .alert {
-    font-size: 14px;
-    text-align: left;
-    line-height: 1.3;
-  }
-
   @media screen and (max-width: 767px) {
     .hero-tron {
       margin-bottom: 0;

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -33,8 +33,6 @@
 <%= content_for :hero do %>
   <h1><%= @video.position %>. <%= @video.title %></h1>
   <p><%= t('.part_of_series_html', playlist: link_to(@video.playlist.title, playlist_path(@video.playlist))) %></p>
-
-  <p class="alert alert-warning"><strong><%= t('.preview') %></strong> <%= t('.unlisted') %></p>
 <% end %>
 
 <div class="row video-player">
@@ -46,14 +44,15 @@
   </div>
 </div>
 
+<% unless @video.scheduled? %>
 <div class="video-toolbar">
-  <% unless @video.first? %>
+  <% unless @video == @playlist.videos.visible.first %>
   <%= link_to t('.previous'), playlist_video_path(@video.higher_item, playlist_id: @playlist), class: 'pull-left btn btn-default' %>
   <% else %>
   <%= link_to t('.previous'), '#', disabled: true, class: 'disabled pull-left btn btn-default' %>
   <% end %>
 
-  <% unless @video.last? %>
+  <% unless @video == @playlist.videos.visible.last %>
   <%= link_to t('.next'), playlist_video_path(@video.lower_item, playlist_id: @playlist), class: 'pull-right btn btn-default' %>
   <% else %>
   <%= link_to t('.next'), '#', disabled: true, class: 'disabled pull-right btn btn-default' %>
@@ -61,6 +60,9 @@
 
   <%= link_to t('.watch_on_youtube'), "https://www.youtube.com/watch?v=#{@video.youtube_id}&list=#{@video.playlist.youtube_id}&index=#{@video.position}", class: 'btn btn-default' %>
 </div>
+<% else %>
+  <p class="alert alert-warning"><strong><%= t('.preview') %></strong> <%= t('.unlisted') %></p>
+<% end %>
 
 <div class="video-information">
 <div class="row">

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -144,7 +144,7 @@ es:
       release_date_html: "Fecha de emisión: %{date}"
       duration: "Duración: %{duration}"
       preview: Esto es una vista previa de un vídeo que próximamente estará en YouTube (imagino).
-      unlisted: Este vídeo está sin listar y por ello no lo encontrarás ni en el canal de YouTube ni en las listas de esta web, en este momento.
+      unlisted: Este vídeo en este momento está sin listar. Si navegas por los vídeos recientes del canal de YouTube o de la web no lo verás. Considera este enlace como un adelanto que podría sufrir modificaciones o ser eliminado si se encuentran errores y conserva el link si quieres volver a verlo antes de que se publique.
       explore_other_videos:
         one: Explora el resto de vídeos de esta lista de reproducción.
         other: Una lista de reproducción de %{count} episodios.


### PR DESCRIPTION
I forgot to remove the toolbar. Apply this PR to remove the toolbar that appears below a video on unlisted videos. There should be no easy way to navigate on them. Plus, don't link to a private video on the toolbar that apears below the previous episode.

Now that the toolbar is gone, move the alert down there.