### PR TITLE
Add HTTP headers for revision and version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,6 @@
 require_relative 'boot'
+require_relative '../lib/makigas/version_header'
+require_relative '../lib/makigas/revision_header'
 
 require 'rails/all'
 
@@ -19,5 +21,9 @@ module Makigas
     # Configure internationalization. What if one day I translate my channel?
     config.i18n.default_locale = :es
     config.i18n.load_path += Dir["#{Rails.root}/config/locales/**/*.yml"]
+
+    # Extra middleware
+    config.middleware.use Makigas::VersionHeader
+    config.middleware.use Makigas::RevisionHeader
   end
 end

--- a/lib/makigas/revision_header.rb
+++ b/lib/makigas/revision_header.rb
@@ -1,0 +1,39 @@
+module Makigas
+  class RevisionHeader
+
+    def initialize(app, options = {})
+      @app = app
+      @options = default_options.merge(options)
+    end
+
+    def call(env)
+      request, headers, response = @app.call(env)
+      headers[@options[:header]] = value unless revision.nil?
+      [request, headers, response]
+    end
+
+    private
+
+    def default_options
+      {
+        header: 'X-VCS-Revision',
+        value: ':REVISION',
+        file: 'REVISION'
+      }
+    end
+
+    def revision
+      if File.exists?(@options[:file])
+        @revision ||= File.read(@options[:file]).strip
+        @revision
+      else
+        nil
+      end
+    end
+
+    def value
+      @options[:value].gsub(':REVISION', revision)
+    end
+
+  end
+end

--- a/lib/makigas/version.rb
+++ b/lib/makigas/version.rb
@@ -1,0 +1,3 @@
+module Makigas
+  VERSION = "5.0.2".freeze
+end

--- a/lib/makigas/version_header.rb
+++ b/lib/makigas/version_header.rb
@@ -1,0 +1,28 @@
+module Makigas
+  class VersionHeader
+    def initialize(app, options = {})
+      @app = app
+      @options = default_options.merge(options)
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      headers[@options[:header]] = value
+      [status, headers, body]
+    end
+
+    private
+
+    def default_options
+      {
+        header: 'X-Powered-By',
+        value: 'makigas/:VERSION'
+      }
+    end
+
+    def value
+      @version ||= Makigas::VERSION
+      @options[:value].gsub(':VERSION', @version)
+    end
+  end
+end


### PR DESCRIPTION
Apply this commit to introduce some middleware to print two additional
headers in requests made to the application:

* X-Powered-By will display the name and the version of the web
  application serving the request. Since this application is somehow
  versioned, it is included.
* X-VCS-Revision will display the actual commit hash that is running.