### PR TITLE
Add support for links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'kaminari'
 gem 'bootstrap-kaminari-views', '~> 0.0.5'
 
 group :development do
+  gem 'annotate'
   gem 'listen', '~> 3.1'
   gem 'web-console'
   gem 'capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,12 @@ end
 
 group :development, :test do
   gem 'byebug'
-  gem 'rspec-rails', '~> 3.4'
   gem 'factory_girl_rails'
   gem 'capybara'
+end
+
+group :test do
+  gem 'rspec-rails', '~> 3.4'
+  gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git', branch: 'rails-5'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    annotate (2.7.2)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 13.0)
     arel (8.0.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
@@ -286,6 +289,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts_as_list
+  annotate
   bootstrap-kaminari-views (~> 0.0.5)
   byebug
   capistrano

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/thoughtbot/shoulda-matchers.git
+  revision: edaf9cb926ee9c59c59729e7a4f8c206b44da8a1
+  branch: rails-5
+  specs:
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -315,6 +323,7 @@ DEPENDENCIES
   rspec-rails (~> 3.4)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-matchers!
   simple_form
   sitemap_generator
   uglifier (>= 1.3.0)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: links
+#
+#  id          :integer          not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  video_id    :integer
+#  url         :string
+#  description :string
+#
+# Indexes
+#
+#  index_links_on_video_id  (video_id)
+#
+
+class Link < ApplicationRecord
+  # Relations
+  belongs_to :video, required: true
+
+  # Validations
+  validates :url, presence: true, length: { maximum: 1024 }
+  validates :description, presence: true, length: { maximum: 256 }
+  validates :video, presence: true
+end

--- a/app/models/opinion.rb
+++ b/app/models/opinion.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: opinions
+#
+#  id                 :integer          not null, primary key
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  from               :string           not null
+#  message            :string           not null
+#  url                :string
+#  photo_file_name    :string           not null
+#  photo_content_type :string           not null
+#  photo_file_size    :integer          not null
+#  photo_updated_at   :datetime         not null
+#
+
 class Opinion < ApplicationRecord
   has_attached_file :photo, styles: {
     default: "320x320>",

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: playlists
+#
+#  id                     :integer          not null, primary key
+#  title                  :string           not null
+#  description            :text             not null
+#  youtube_id             :string           not null
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  topic_id               :integer
+#  thumbnail_file_name    :string
+#  thumbnail_content_type :string
+#  thumbnail_file_size    :integer
+#  thumbnail_updated_at   :datetime
+#  card_file_name         :string
+#  card_content_type      :string
+#  card_file_size         :integer
+#  card_updated_at        :datetime
+#
+# Indexes
+#
+#  index_playlists_on_slug  (slug) UNIQUE
+#
+
 class Playlist < ApplicationRecord
   extend FriendlyId
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id                     :integer          not null, primary key
+#  title                  :string           not null
+#  description            :string           not null
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  thumbnail_file_name    :string
+#  thumbnail_content_type :string
+#  thumbnail_file_size    :integer
+#  thumbnail_updated_at   :datetime
+#  color                  :string
+#
+# Indexes
+#
+#  index_topics_on_slug  (slug) UNIQUE
+#
+
 class Topic < ApplicationRecord
   extend FriendlyId
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :inet
+#  last_sign_in_ip        :inet
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -29,6 +29,9 @@ class Video < ApplicationRecord
   belongs_to :playlist
   acts_as_list scope: :playlist
 
+  # Videos can have links
+  has_many :links
+
   # Slug. Can be repeated as long as it's on different playlists.
   friendly_id :title, use: [:slugged, :scoped], scope: :playlist
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: videos
+#
+#  id           :integer          not null, primary key
+#  title        :string           not null
+#  description  :text             not null
+#  youtube_id   :string           not null
+#  duration     :integer          not null
+#  slug         :string           not null
+#  playlist_id  :integer          not null
+#  position     :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  unfeatured   :boolean          default(FALSE), not null
+#  published_at :datetime         not null
+#  private      :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_videos_on_slug        (slug)
+#  index_videos_on_youtube_id  (youtube_id) UNIQUE
+#
+
 class Video < ApplicationRecord
   extend FriendlyId
 

--- a/db/migrate/20170816103148_create_links.rb
+++ b/db/migrate/20170816103148_create_links.rb
@@ -1,0 +1,10 @@
+class CreateLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :links do |t|
+      t.timestamps
+      t.references :video, required: true, indexed: true
+      t.string :url, length: 1024, required: true
+      t.string :description, length: 256, required: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,88 +10,97 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170417204245) do
+ActiveRecord::Schema.define(version: 20170816103148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "opinions", force: :cascade do |t|
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.string   "from",               null: false
-    t.string   "message",            null: false
-    t.string   "url"
-    t.string   "photo_file_name",    null: false
-    t.string   "photo_content_type", null: false
-    t.integer  "photo_file_size",    null: false
-    t.datetime "photo_updated_at",   null: false
+  create_table "links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "video_id"
+    t.string "url"
+    t.string "description"
+    t.index ["video_id"], name: "index_links_on_video_id"
   end
 
-  create_table "playlists", force: :cascade do |t|
-    t.string   "title",                  null: false
-    t.text     "description",            null: false
-    t.string   "youtube_id",             null: false
-    t.string   "slug",                   null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "topic_id"
-    t.string   "thumbnail_file_name"
-    t.string   "thumbnail_content_type"
-    t.integer  "thumbnail_file_size"
+  create_table "opinions", id: :serial, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "from", null: false
+    t.string "message", null: false
+    t.string "url"
+    t.string "photo_file_name", null: false
+    t.string "photo_content_type", null: false
+    t.integer "photo_file_size", null: false
+    t.datetime "photo_updated_at", null: false
+  end
+
+  create_table "playlists", id: :serial, force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description", null: false
+    t.string "youtube_id", null: false
+    t.string "slug", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "topic_id"
+    t.string "thumbnail_file_name"
+    t.string "thumbnail_content_type"
+    t.integer "thumbnail_file_size"
     t.datetime "thumbnail_updated_at"
-    t.string   "card_file_name"
-    t.string   "card_content_type"
-    t.integer  "card_file_size"
+    t.string "card_file_name"
+    t.string "card_content_type"
+    t.integer "card_file_size"
     t.datetime "card_updated_at"
-    t.index ["slug"], name: "index_playlists_on_slug", unique: true, using: :btree
+    t.index ["slug"], name: "index_playlists_on_slug", unique: true
   end
 
-  create_table "topics", force: :cascade do |t|
-    t.string   "title",                  null: false
-    t.string   "description",            null: false
-    t.string   "slug",                   null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "thumbnail_file_name"
-    t.string   "thumbnail_content_type"
-    t.integer  "thumbnail_file_size"
+  create_table "topics", id: :serial, force: :cascade do |t|
+    t.string "title", null: false
+    t.string "description", null: false
+    t.string "slug", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "thumbnail_file_name"
+    t.string "thumbnail_content_type"
+    t.integer "thumbnail_file_size"
     t.datetime "thumbnail_updated_at"
-    t.string   "color"
-    t.index ["slug"], name: "index_topics_on_slug", unique: true, using: :btree
+    t.string "color"
+    t.index ["slug"], name: "index_topics_on_slug", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "videos", force: :cascade do |t|
-    t.string   "title",                        null: false
-    t.text     "description",                  null: false
-    t.string   "youtube_id",                   null: false
-    t.integer  "duration",                     null: false
-    t.string   "slug",                         null: false
-    t.integer  "playlist_id",                  null: false
-    t.integer  "position",                     null: false
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.boolean  "unfeatured",   default: false, null: false
-    t.datetime "published_at",                 null: false
-    t.boolean  "private",      default: false, null: false
-    t.index ["slug"], name: "index_videos_on_slug", using: :btree
-    t.index ["youtube_id"], name: "index_videos_on_youtube_id", unique: true, using: :btree
+  create_table "videos", id: :serial, force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description", null: false
+    t.string "youtube_id", null: false
+    t.integer "duration", null: false
+    t.string "slug", null: false
+    t.integer "playlist_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "unfeatured", default: false, null: false
+    t.datetime "published_at", null: false
+    t.boolean "private", default: false, null: false
+    t.index ["slug"], name: "index_videos_on_slug"
+    t.index ["youtube_id"], name: "index_videos_on_youtube_id", unique: true
   end
 
 end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,53 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'routes'                    => 'false',
+      'position_in_routes'        => 'before',
+      'position_in_class'         => 'before',
+      'position_in_test'          => 'before',
+      'position_in_fixture'       => 'before',
+      'position_in_factory'       => 'before',
+      'position_in_serializer'    => 'before',
+      'show_foreign_keys'         => 'true',
+      'show_complete_foreign_keys' => 'false',
+      'show_indexes'              => 'true',
+      'simple_indexes'            => 'false',
+      'model_dir'                 => 'app/models',
+      'root_dir'                  => '',
+      'include_version'           => 'false',
+      'require'                   => '',
+      'exclude_tests'             => 'false',
+      'exclude_fixtures'          => 'false',
+      'exclude_factories'         => 'false',
+      'exclude_serializers'       => 'false',
+      'exclude_scaffolds'         => 'true',
+      'exclude_controllers'       => 'true',
+      'exclude_helpers'           => 'true',
+      'exclude_sti_subclasses'    => 'false',
+      'ignore_model_sub_dir'      => 'false',
+      'ignore_columns'            => nil,
+      'ignore_routes'             => nil,
+      'ignore_unknown_models'     => 'false',
+      'hide_limit_column_types'   => 'integer,boolean',
+      'hide_default_column_types' => 'json,jsonb,hstore',
+      'skip_on_db_migrate'        => 'false',
+      'format_bare'               => 'true',
+      'format_rdoc'               => 'false',
+      'format_markdown'           => 'false',
+      'sort'                      => 'false',
+      'force'                     => 'false',
+      'trace'                     => 'false',
+      'wrapper_open'              => nil,
+      'wrapper_close'             => nil,
+      'with_comment'              => true
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: links
+#
+#  id          :integer          not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  video_id    :integer
+#  url         :string
+#  description :string
+#
+# Indexes
+#
+#  index_links_on_video_id  (video_id)
+#
+
+FactoryGirl.define do
+  factory :link do
+    association :video, factory: :video
+    url 'https://www.ruby-lang.org'
+    description 'Official website for the Ruby programming language'
+  end
+end

--- a/spec/factories/opinions.rb
+++ b/spec/factories/opinions.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: opinions
+#
+#  id                 :integer          not null, primary key
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  from               :string           not null
+#  message            :string           not null
+#  url                :string
+#  photo_file_name    :string           not null
+#  photo_content_type :string           not null
+#  photo_file_size    :integer          not null
+#  photo_updated_at   :datetime         not null
+#
+
 FactoryGirl.define do
   factory :opinion do
     from 'Programación & Co.'

--- a/spec/factories/playlists.rb
+++ b/spec/factories/playlists.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: playlists
+#
+#  id                     :integer          not null, primary key
+#  title                  :string           not null
+#  description            :text             not null
+#  youtube_id             :string           not null
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  topic_id               :integer
+#  thumbnail_file_name    :string
+#  thumbnail_content_type :string
+#  thumbnail_file_size    :integer
+#  thumbnail_updated_at   :datetime
+#  card_file_name         :string
+#  card_content_type      :string
+#  card_file_size         :integer
+#  card_updated_at        :datetime
+#
+# Indexes
+#
+#  index_playlists_on_slug  (slug) UNIQUE
+#
+
 include ActionDispatch::TestProcess
 
 FactoryGirl.define do

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id                     :integer          not null, primary key
+#  title                  :string           not null
+#  description            :string           not null
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  thumbnail_file_name    :string
+#  thumbnail_content_type :string
+#  thumbnail_file_size    :integer
+#  thumbnail_updated_at   :datetime
+#  color                  :string
+#
+# Indexes
+#
+#  index_topics_on_slug  (slug) UNIQUE
+#
+
 FactoryGirl.define do
   factory :topic do
     title 'Popular musics'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :inet
+#  last_sign_in_ip        :inet
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+
 FactoryGirl.define do
   factory :user do
     email 'makigas@example.com'

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: videos
+#
+#  id           :integer          not null, primary key
+#  title        :string           not null
+#  description  :text             not null
+#  youtube_id   :string           not null
+#  duration     :integer          not null
+#  slug         :string           not null
+#  playlist_id  :integer          not null
+#  position     :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  unfeatured   :boolean          default(FALSE), not null
+#  published_at :datetime         not null
+#  private      :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_videos_on_slug        (slug)
+#  index_videos_on_youtube_id  (youtube_id) UNIQUE
+#
+
 FactoryGirl.define do
   factory :video do
     title 'Chandelier'

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: links
+#
+#  id          :integer          not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  video_id    :integer
+#  url         :string
+#  description :string
+#
+# Indexes
+#
+#  index_links_on_video_id  (video_id)
+#
+
+require 'rails_helper'
+
+RSpec.describe Link, type: :model do
+  describe 'has a valid factory' do
+    subject { FactoryGirl.build(:link) }
+    it { is_expected.to be_valid }
+  end
+
+  context 'validation' do
+    it { is_expected.to validate_presence_of :url }
+    it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :video }
+    it { is_expected.to validate_length_of(:url).is_at_most 1024 }
+    it { is_expected.to validate_length_of(:description).is_at_most 256 }
+  end
+
+  context 'relationship' do
+    it { is_expected.to belong_to :video }
+  end
+end

--- a/spec/models/opinion_spec.rb
+++ b/spec/models/opinion_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: opinions
+#
+#  id                 :integer          not null, primary key
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  from               :string           not null
+#  message            :string           not null
+#  url                :string
+#  photo_file_name    :string           not null
+#  photo_content_type :string           not null
+#  photo_file_size    :integer          not null
+#  photo_updated_at   :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe Opinion, type: :model do

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: playlists
+#
+#  id                     :integer          not null, primary key
+#  title                  :string           not null
+#  description            :text             not null
+#  youtube_id             :string           not null
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  topic_id               :integer
+#  thumbnail_file_name    :string
+#  thumbnail_content_type :string
+#  thumbnail_file_size    :integer
+#  thumbnail_updated_at   :datetime
+#  card_file_name         :string
+#  card_content_type      :string
+#  card_file_size         :integer
+#  card_updated_at        :datetime
+#
+# Indexes
+#
+#  index_playlists_on_slug  (slug) UNIQUE
+#
+
 require 'rails_helper'
 
 RSpec.describe Playlist, type: :model do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id                     :integer          not null, primary key
+#  title                  :string           not null
+#  description            :string           not null
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  thumbnail_file_name    :string
+#  thumbnail_content_type :string
+#  thumbnail_file_size    :integer
+#  thumbnail_updated_at   :datetime
+#  color                  :string
+#
+# Indexes
+#
+#  index_topics_on_slug  (slug) UNIQUE
+#
+
 require 'rails_helper'
 
 RSpec.describe Topic, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :inet
+#  last_sign_in_ip        :inet
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+
 require 'rails_helper'
 
 RSpec.describe User, type: :model do

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: videos
+#
+#  id           :integer          not null, primary key
+#  title        :string           not null
+#  description  :text             not null
+#  youtube_id   :string           not null
+#  duration     :integer          not null
+#  slug         :string           not null
+#  playlist_id  :integer          not null
+#  position     :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  unfeatured   :boolean          default(FALSE), not null
+#  published_at :datetime         not null
+#  private      :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_videos_on_slug        (slug)
+#  index_videos_on_youtube_id  (youtube_id) UNIQUE
+#
+
 require 'rails_helper'
 
 RSpec.describe Video, type: :model do

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -43,63 +43,23 @@ RSpec.describe Video, type: :model do
   end
 
   context 'validation' do
-    it 'is not valid without title' do
-      video = FactoryGirl.build(:video, title: nil)
-      expect(video).not_to be_valid
-    end
+    it { is_expected.to validate_presence_of :title }
+    it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :youtube_id }
+    it { is_expected.to validate_presence_of :duration }
+    it { is_expected.to validate_presence_of :playlist }
+    it { is_expected.to validate_presence_of :published_at }
 
-    it 'is not valid with a long title' do
-      video = FactoryGirl.build(:video, title: 'A' * 101)
-      expect(video).not_to be_valid
-    end
+    it { is_expected.to validate_length_of(:title).is_at_most 100 }
+    it { is_expected.to validate_length_of(:description).is_at_most 1500 }
+    it { is_expected.to validate_length_of(:youtube_id).is_at_most 15 }
+    
+    it { is_expected.to validate_numericality_of(:duration).is_greater_than 0 }
+  end
 
-    it 'is not valid without description' do
-      video = FactoryGirl.build(:video, description: nil)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid without a long description' do
-      video = FactoryGirl.build(:video, description: 'A' * 1501)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid without YouTube ID' do
-      video = FactoryGirl.build(:video, youtube_id: nil)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid with a long YouTube ID' do
-      video = FactoryGirl.build(:video, youtube_id: 'A' * 16)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid without duration' do
-      video = FactoryGirl.build(:video, duration: nil)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid with zero duration' do
-      video = FactoryGirl.build(:video, duration: 0)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid with negative duration' do
-      video = FactoryGirl.build(:video, duration: -1)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid without being in a playlist' do
-      video = FactoryGirl.build(:video, playlist: nil)
-      expect(video).not_to be_valid
-    end
-
-    it 'is not valid without a publishing date' do
-      video = FactoryGirl.build(:video, published_at: nil)
-      expect(video).not_to be_valid
-    end
-
-    # Note: I don't have to test whether videos are valid without position or
-    # when positions are negative since apparently acts_as_list checks this.
+  context 'relationship' do
+    it { is_expected.to belong_to :playlist }
+    it { is_expected.to have_many :links }
   end
 
   context 'slug' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
   
   config.include Capybara::DSL
   config.include Warden::Test::Helpers


### PR DESCRIPTION
Links are currently displayed in the video description but have no proper treatment. They are read only, they cannot be clicked and it's clunky to manage them because it's just another word in the description.

This PR adds support for proper links. Links are entities with a descrpition and an URL. They can be managed outside the video description and they can be displayed outside the video description using real hyperlinks that point somewhere when clicked.

Tracking issue: #10