### PR TITLE
Fix dashboard front-end shenanigans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,7 @@ before_install:
       tar -xvf $PWD/phantomjs-2.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs --strip-components 2 phantomjs-2.1.1-linux-x86_64/bin/phantomjs;
     fi
 
-before_script:
-- bundle exec rake db:create yarn:install
-- RAILS_ENV=test bundle exec rails webpacker:compile
-
+before_script: bundle exec rake db:create yarn:install
 script: PATH=$PWD/travis-phantomjs:$PATH bundle exec rspec spec
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ services:
 
 env:
   - DB_USERNAME=postgres
-  - PATH=$PWD/travis-phantomjs:$PATH
 
 before_install:
   - nvm install 6
@@ -24,7 +23,7 @@ before_script:
 - bundle exec rake db:create yarn:install
 - RAILS_ENV=test bundle exec rails webpacker:compile
 
-script: bundle exec rspec spec
+script: PATH=$PWD/travis-phantomjs:$PATH bundle exec rspec spec
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,30 @@ branches:
 rvm: 2.4.1
 services:
   - postgresql
+
 env:
   - DB_USERNAME=postgres
+  - PATH=$PWD/travis-phantomjs:$PATH
+
 before_install:
   - nvm install 6
   - nvm use 6
   - node -v
   - npm install -g yarn
+  - if [ ! -f $PWD/travis-phantomjs/phantomjs ]; then
+      wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/phantomjs-2.1-linux-x86_64.tar.bz2;
+      tar -xvf $PWD/phantomjs-2.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs --strip-components 2 phantomjs-2.1.1-linux-x86_64/bin/phantomjs;
+    fi
+
 before_script:
 - bundle exec rake db:create yarn:install
 - RAILS_ENV=test bundle exec rails webpacker:compile
+
 script: bundle exec rspec spec
+
 cache:
   bundler: true
   directories:
   - node_modules
+  - $PWD/travis-phantomjs
   yarn: true

--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,6 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.4'
   gem 'factory_girl_rails'
   gem 'capybara'
+  gem 'poltergeist'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/webpacker.git
-  revision: 7a1d306f367174e39c815bd298ab5d61cbbde72e
+  revision: c6106c4d1bdb05a5d0df1caa0edb7ddeceab5463
   specs:
     webpacker (2.0)
       activesupport (>= 4.2)
@@ -179,7 +179,7 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     public_suffix (2.0.5)
-    puma (3.9.1)
+    puma (3.10.0)
     rack (2.0.3)
     rack-proxy (0.6.2)
       rack
@@ -271,7 +271,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     temple (0.8.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tzinfo (1.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       xpath (~> 2.0)
     chronic (0.10.2)
     climate_control (0.2.0)
+    cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     concurrent-ruby (1.0.5)
@@ -173,6 +174,10 @@ GEM
       mime-types
       mimemagic (~> 0.3.0)
     pg (0.21.0)
+    poltergeist (1.16.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
@@ -310,6 +315,7 @@ DEPENDENCIES
   listen (~> 3.1)
   paperclip
   pg
+  poltergeist
   puma (~> 3.0)
   rails (= 5.1.3)
   rails-i18n (~> 5.0.0)

--- a/app/assets/javascripts/dashboard/videos.js
+++ b/app/assets/javascripts/dashboard/videos.js
@@ -1,46 +1,16 @@
 window.addEventListener('load', function() {
   if (!document.body.classList.contains('page-videos')) return;
 
+  /* On form submission, update the video duration hidden field. */
   var form = document.querySelector('form.simple_form');
+  form && form.addEventListener('submit', function() {
+    // Extract sexagesimal time values.
+    var hh = form.querySelector('#duration_hours').value || 0;
+    var mm = form.querySelector('#duration_minutes').value || 0;
+    var ss = form.querySelector('#duration_seconds').value || 0;
 
-  // Check that there is actually a form in this page.
-  if (form == null) return;
-
-  /**
-   * Updates the hidden duration field using the sexagesimal values.
-   * Because setting the duration using seconds would be hard when the
-   * video lasts more than 60 seconds, the duration is set using hours,
-   * minutes and seconds by the user. This function will update the
-   * hidden duration value which is the value actually sent to the
-   * server.
-   */
-  var updateDuration = function() {
-    // Get the current sexagesimal time.
-    var hours = parseInt(form.querySelector('#duration_hours').value) || 0;
-    var minutes = parseInt(form.querySelector("#duration_minutes").value) || 0;
-    var seconds = parseInt(form.querySelector("#duration_seconds")) || 0;
-
-    // Update the hidden actual seconds value.
-    var duration = hours * 3600 + minutes * 60 + seconds;
-    form.querySelector('#video_duration').value = duration;
-  };
-
-  [
-    form.querySelector("#duration_hours"),
-    form.querySelector("#duration_minutes"),
-    form.querySelector("#duration_seconds")
-  ].forEach(function(item) {
-    item.addEventListener('change', updateDuration);
-    item.addEventListener('keyup', updateDuration);
-    item.addEventListener('blur', function(e) {
-      if (e.target.value == "") {
-        e.target.value = 0;
-      } else {
-        var realValue = parseInt(e.target.value);
-        if (realValue < 0) {
-          e.target.value = 0;
-        }
-      }
-    });
+    // Convert to seconds.
+    var time = parseInt(hh) * 3600 + parseInt(mm) * 60 + parseInt(ss);
+    form.querySelector('#video_duration').value = time;
   });
 });

--- a/app/assets/javascripts/dashboard/videos.js
+++ b/app/assets/javascripts/dashboard/videos.js
@@ -1,9 +1,12 @@
-window.addEventListener('load', function() {
-  if (!document.body.classList.contains('page-videos')) return;
+/*
+ * On form submission, the sexagesimal components for the video
+ * length should be extracted and the duration in seconds should be
+ * calculated, as that is what has to be sent to the backend.
+ */
+var form = document.querySelector('body.page-videos form.simple_form');
 
-  /* On form submission, update the video duration hidden field. */
-  var form = document.querySelector('form.simple_form');
-  form && form.addEventListener('submit', function() {
+if (form) {
+  form.addEventListener('submit', function(e) {
     // Extract sexagesimal time values.
     var hh = form.querySelector('#duration_hours').value || 0;
     var mm = form.querySelector('#duration_minutes').value || 0;
@@ -13,4 +16,4 @@ window.addEventListener('load', function() {
     var time = parseInt(hh) * 3600 + parseInt(mm) * 60 + parseInt(ss);
     form.querySelector('#video_duration').value = time;
   });
-});
+}

--- a/app/views/dashboard/videos/_form.html.erb
+++ b/app/views/dashboard/videos/_form.html.erb
@@ -5,9 +5,9 @@
   <%= form.input :duration, as: :numeric do %>
     <%= form.hidden_field :duration %>
     <p class="form-inline">
-    <%= number_field_tag 'duration[hours]', ((@video.duration / 3600) rescue "0"), class: 'form-control', min: 0, max: 9 %> :
-    <%= number_field_tag 'duration[minutes]', (((@video.duration % 3600) / 60) rescue 0), class: 'form-control', min: 0, max: 59 %> :
-    <%= number_field_tag 'duration[seconds]', ((@video.duration % 60) rescue 0), class: 'form-control', min: 0, max: 59 %>
+    <%= number_field_tag nil, ((@video.duration / 3600) rescue "0"), id: 'duration_hours', class: 'form-control', min: 0, max: 9 %> :
+    <%= number_field_tag nil, (((@video.duration % 3600) / 60) rescue 0), id: 'duration_minutes', class: 'form-control', min: 0, max: 59 %> :
+    <%= number_field_tag nil, ((@video.duration % 60) rescue 0), id: 'duration_seconds', class: 'form-control', min: 0, max: 59 %>
     </p>
   <% end %>
   <%= form.association :playlist, include_blank: :translate %>

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -6,6 +6,11 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
     Capybara.server_port = 9080
   end
 
+  after do
+    Capybara.app_host = nil
+    Capybara.server_port = nil
+  end
+
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_videos_path

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature "Dashboard videos", type: :feature do
-  before { Capybara.default_host = "http://dashboard.example.com" }
-  after { Capybara.default_host = "http://www.example.com" }
+RSpec.feature "Dashboard videos", type: :feature, js: true do
+  before do
+    Capybara.app_host = 'http://dashboard.lvh.me:9080'
+    Capybara.server_port = 9080
+  end
 
   context "when not logged in" do
     it "should not be success" do
@@ -32,16 +34,32 @@ RSpec.feature "Dashboard videos", type: :feature do
         fill_in 'Título', with: 'My video title'
         fill_in 'Descripción', with: 'This is my newest and coolest video'
         fill_in 'ID de YouTube', with: 'dQw4w9WgXcQ'
-        # TODO: Should test the actual interaction with duration controls.
-        # (They require JavaScript and I'll prefer to finish this test suite
-        # before adding extra dependencies that could break existing tests)
-        find(:xpath, "//input[@id='video_duration']", visible: false).set '212'
+        fill_in 'duration_minutes', with: '3'
+        fill_in 'duration_seconds', with: '32'
         select @playlist.title, from: 'Lista de reproducción'
         click_button 'Crear Vídeo'
       }.to change { Video.count }.by 1
 
       expect(page).to have_text 'Vídeo creado correctamente'
       expect(@playlist.videos.count).to eq 1
+    end
+
+    scenario "user can set the duration of a video" do
+      @playlist = FactoryGirl.create(:playlist)
+      visit dashboard_videos_path
+      
+      click_link 'Nuevo Vídeo'
+      fill_in 'Título', with: 'My video title'
+      fill_in 'Descripción', with: 'This is a long video'
+      fill_in 'ID de YouTube', with: 'dQw4w9WgXcQ'
+      select @playlist.title, from: 'Lista de reproducción'
+      fill_in 'duration_hours', with: '1'
+      fill_in 'duration_minutes', with: '5'
+      fill_in 'duration_seconds', with: '40'
+      click_button 'Crear Vídeo'
+
+      expect(page).to have_text 'Vídeo creado correctamente'
+      expect(page).to have_text '1:05:40'
     end
 
     scenario "user can create unfeatured videos" do
@@ -53,17 +71,15 @@ RSpec.feature "Dashboard videos", type: :feature do
         fill_in 'Título', with: 'My video title'
         fill_in 'Descripción', with: 'This is my newest and coolest video'
         fill_in 'ID de YouTube', with: 'dQw4w9WgXcQ'
-        # TODO: Should test the actual interaction with duration controls.
-        # (They require JavaScript and I'll prefer to finish this test suite
-        # before adding extra dependencies that could break existing tests)
-        find(:xpath, "//input[@id='video_duration']", visible: false).set '212'
+        fill_in 'duration_minutes', with: '3'
+        fill_in 'duration_seconds', with: '32'
         select @playlist.title, from: 'Lista de reproducción'
         check 'video_unfeatured'
         click_button 'Crear Vídeo'
       }.to change { Video.count }.by 1
 
       # Test the video does not appear
-      Capybara.default_host = "http://www.example.com"
+      Capybara.app_host = "http://www.lvh.me:9080"
       visit root_path
       within '.recent-videos' do
         expect(page).not_to have_link 'My video title'
@@ -90,10 +106,8 @@ RSpec.feature "Dashboard videos", type: :feature do
         fill_in 'Título', with: 'My video title'
         fill_in 'Descripción', with: 'This is my newest and coolest video'
         fill_in 'ID de YouTube', with: 'dQw4w9WgXcQ'
-        # TODO: Should test the actual interaction with duration controls.
-        # (They require JavaScript and I'll prefer to finish this test suite
-        # before adding extra dependencies that could break existing tests)
-        find(:xpath, "//input[@id='video_duration']", visible: false).set '212'
+        fill_in 'duration_minutes', with: '3'
+        fill_in 'duration_seconds', with: '32'
         click_button 'Crear Vídeo'
       }.not_to change { Video.count }
       expect(page).not_to have_text 'Vídeo creado correctamente'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rspec'
+require 'capybara/poltergeist'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -58,4 +59,6 @@ RSpec.configure do |config|
   
   config.include Capybara::DSL
   config.include Warden::Test::Helpers
+
+  Capybara.javascript_driver = :poltergeist
 end


### PR DESCRIPTION
Some of the JavaScript code used for the duration component in the dashboard video editor seem to have regressions, possibly introduced in #63 during the port to vanilla JS.

Anyway, JS hasn't ever been tested. This PR should also fix that by adding support for a JavaScript engine in Capybara and using it instead of the default stack when running some feature tests for pages that depend on JavaScript to work.