### PR TITLE
S3 Storage support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'webpacker', '~> 3.0'
 
 gem 'devise'
 gem 'paperclip'
+gem 'aws-sdk', '~> 2.3.0'
 gem 'friendly_id'
 gem 'acts_as_list'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
+    aws-sdk (2.3.22)
+      aws-sdk-resources (= 2.3.22)
+    aws-sdk-core (2.3.22)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.3.22)
+      aws-sdk-core (= 2.3.22)
     bcrypt (3.1.11)
     bindex (0.5.0)
     bootstrap-kaminari-views (0.0.5)
@@ -123,6 +129,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.3.1)
     json (1.8.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -296,6 +303,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts_as_list
+  aws-sdk (~> 2.3.0)
   bootstrap-kaminari-views (~> 0.0.5)
   byebug
   capistrano

--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ Stop a development session by using `docker-compose stop` or
 `docker-compose down`. First command will stop the containers but won't delete
 them. Second command will also delete the containers.
 
+**It's slow**. First request may be slow if Webpacker needs compiling the
+application. This has to do more with Webpacker than Docker, but the fact that
+restarting Docker containers may make compiled assets to be lost, makes this
+thing happen more.
+
+**A server is already running. Check /makigas/tmp/pids/server.pid.**
+This bug happens some times when a Docker container is not gracefully stopped
+or the container is not clean up anyway. I still don't know a more proper way
+to deal with this other than opening a second shell and running
+`docker-compose exec web rm /makigas/tmp/pids/server.pid` to delete the old
+PID file.
+
 ## Testing commands
 
 * Change directory to `spec` to use `spec/docker-compose.yml`. This compose

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -2,6 +2,14 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
+<link rel="dns-prefetch" href="//cdn.makigas.es">
+<link rel="dns-prefetch" href="//static.makigas.es">
+<link rel="dns-prefetch" href="//disqus.com">
+<link rel="dns-prefetch" href="//i1.ytimg.com">
+<link rel="dns-prefetch" href="//www.google-analytics.com">
+<link rel="dns-prefetch" href="//www.youtube-nocookie.com">
+<link rel="dns-prefetch" href="//makigas.disqus.com">
+
 <title><%= content_for?(:title) ? content_for(:title) : "makigas" %></title>
 <%= tag(:meta, name: 'description', content: content_for(:description)) if content_for?(:description) %>
 <%= tag(:link, rel: 'canonical', href: canonical_url) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,57 +19,5 @@ module Makigas
     # Configure internationalization. What if one day I translate my channel?
     config.i18n.default_locale = :es
     config.i18n.load_path += Dir["#{Rails.root}/config/locales/**/*.yml"]
-
-    if ENV["RAILS_USE_S3"].present?
-      # Base settings, they work on all cases.
-      config.paperclip_defaults = {
-        storage: :s3,
-        s3_credentials: {
-          bucket: ENV['S3_BUCKET_NAME'],
-          region: ENV.fetch('AWS_REGION') { 'us-east-1' },
-          access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-          secret_key_id: ENV['AWS_SECRET_KEY_ID']
-        }
-      }
-
-      # Use custom host as primary (s3-us-west-2 instead of s3, for instance).
-      # URL before:            s3.amazonaws.com/cdn.makigas.es/hi.css
-      # URL after:   s3-us-west-2.amazonaws.com/cdn.makigas.es/hi.css
-      Paperclip::Attachment.default_options[:s3_host_name] = ENV['S3_HOST_NAME'] if ENV['S3_HOST_NAME'].present?
-
-      # Put the bucket in the domain if this env is set to any value.
-      # URLs will be like cdn.makigas.es.s3.amazonaws.com/hi.css
-      # instead of s3.amazonaws.com/cdn.makigas.es/hi.css
-      # Domain name acts as bucket. This block has two use cases:
-      # 1. Use bucket name in subdomain, as cdn.makigas.es.s3.amazonaws.com.
-      #    Set S3_BUCKET_DOMAIN env variable to any value to enable this.
-      #    URL before:    s3.amazonaws.com/cdn.makigas.es/hi.css
-      #    URL after:     cdn.makigas.es.s3.amazonaws.com/hi.css
-      # 2. Use an alias domain, as cdn.makigas.es Set S3_HOST_ALIAS to the
-      #    host alias to use as domain to enable this.
-      #    URL before:    s3.amazonaws.com/cdn.makigas.es/hi.css
-      #    URL after:     cdn.makigas.es/hi.css
-      #    S3_HOST_ALIAS is set to cdn.makigas.es. Usually this domain will
-      #    have a CNAME pointing to the bucket domain, although this block
-      #    won't care about it as the purpose here is to set the URLs.
-      if ENV['S3_BUCKET_DOMAIN'].present? || ENV['S3_HOST_ALIAS'].present?
-        Paperclip::Attachment.default_options[:path] = '/:class/:attachment/:id_partition/:style/:filename'
-        if ENV['S3_HOST_ALIAS'].present?
-          Paperclip::Attachment.default_options[:s3_host_alias] = ENV['S3_HOST_ALIAS']
-          Paperclip::Attachment.default_options[:url] = ':s3_alias_url'
-        else
-          Paperclip::Attachment.default_options[:url] = ':s3_domain_url'
-        end
-      end
-
-      # Use a custom endpoint (for instance, Minio or other S3-like APIs)
-      if ENV['S3_ENDPOINT'].present?
-        Paperclip::Attachment.default_options[:s3_region] = ENV.fetch('AWS_REGION') { 'us-east-1' }
-        Paperclip::Attachment.default_options[:s3_options] = {
-          force_path_style: true,
-          endpoint: ENV['S3_ENDPOINT']
-        }
-      end
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,57 @@ module Makigas
     # Configure internationalization. What if one day I translate my channel?
     config.i18n.default_locale = :es
     config.i18n.load_path += Dir["#{Rails.root}/config/locales/**/*.yml"]
+
+    if ENV["RAILS_USE_S3"].present?
+      # Base settings, they work on all cases.
+      config.paperclip_defaults = {
+        storage: :s3,
+        s3_credentials: {
+          bucket: ENV['S3_BUCKET_NAME'],
+          region: ENV.fetch('AWS_REGION') { 'us-east-1' },
+          access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+          secret_key_id: ENV['AWS_SECRET_KEY_ID']
+        }
+      }
+
+      # Use custom host as primary (s3-us-west-2 instead of s3, for instance).
+      # URL before:            s3.amazonaws.com/cdn.makigas.es/hi.css
+      # URL after:   s3-us-west-2.amazonaws.com/cdn.makigas.es/hi.css
+      Paperclip::Attachment.default_options[:s3_host_name] = ENV['S3_HOST_NAME'] if ENV['S3_HOST_NAME'].present?
+
+      # Put the bucket in the domain if this env is set to any value.
+      # URLs will be like cdn.makigas.es.s3.amazonaws.com/hi.css
+      # instead of s3.amazonaws.com/cdn.makigas.es/hi.css
+      # Domain name acts as bucket. This block has two use cases:
+      # 1. Use bucket name in subdomain, as cdn.makigas.es.s3.amazonaws.com.
+      #    Set S3_BUCKET_DOMAIN env variable to any value to enable this.
+      #    URL before:    s3.amazonaws.com/cdn.makigas.es/hi.css
+      #    URL after:     cdn.makigas.es.s3.amazonaws.com/hi.css
+      # 2. Use an alias domain, as cdn.makigas.es Set S3_HOST_ALIAS to the
+      #    host alias to use as domain to enable this.
+      #    URL before:    s3.amazonaws.com/cdn.makigas.es/hi.css
+      #    URL after:     cdn.makigas.es/hi.css
+      #    S3_HOST_ALIAS is set to cdn.makigas.es. Usually this domain will
+      #    have a CNAME pointing to the bucket domain, although this block
+      #    won't care about it as the purpose here is to set the URLs.
+      if ENV['S3_BUCKET_DOMAIN'].present? || ENV['S3_HOST_ALIAS'].present?
+        Paperclip::Attachment.default_options[:path] = '/:class/:attachment/:id_partition/:style/:filename'
+        if ENV['S3_HOST_ALIAS'].present?
+          Paperclip::Attachment.default_options[:s3_host_alias] = ENV['S3_HOST_ALIAS']
+          Paperclip::Attachment.default_options[:url] = ':s3_alias_url'
+        else
+          Paperclip::Attachment.default_options[:url] = ':s3_domain_url'
+        end
+      end
+
+      # Use a custom endpoint (for instance, Minio or other S3-like APIs)
+      if ENV['S3_ENDPOINT'].present?
+        Paperclip::Attachment.default_options[:s3_region] = ENV.fetch('AWS_REGION') { 'us-east-1' }
+        Paperclip::Attachment.default_options[:s3_options] = {
+          force_path_style: true,
+          endpoint: ENV['S3_ENDPOINT']
+        }
+      end
+    end
   end
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,0 +1,51 @@
+if ENV["RAILS_USE_S3"].present?
+  # Base settings, they work on all cases.
+  Paperclip::Attachment.default_options.update(
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV['S3_BUCKET_NAME'],
+      region: ENV.fetch('AWS_REGION') { 'us-east-1' },
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_key_id: ENV['AWS_SECRET_KEY_ID']
+    }
+  )
+
+  # Use custom host as primary (s3-us-west-2 instead of s3, for instance).
+  # URL before:            s3.amazonaws.com/cdn.makigas.es/hi.css
+  # URL after:   s3-us-west-2.amazonaws.com/cdn.makigas.es/hi.css
+  Paperclip::Attachment.default_options[:s3_host_name] = ENV['S3_HOST_NAME'] if ENV['S3_HOST_NAME'].present?
+
+  # Put the bucket in the domain if this env is set to any value.
+  # URLs will be like cdn.makigas.es.s3.amazonaws.com/hi.css
+  # instead of s3.amazonaws.com/cdn.makigas.es/hi.css
+  # Domain name acts as bucket. This block has two use cases:
+  # 1. Use bucket name in subdomain, as cdn.makigas.es.s3.amazonaws.com.
+  #    Set S3_BUCKET_DOMAIN env variable to any value to enable this.
+  #    URL before:    s3.amazonaws.com/cdn.makigas.es/hi.css
+  #    URL after:     cdn.makigas.es.s3.amazonaws.com/hi.css
+  # 2. Use an alias domain, as cdn.makigas.es Set S3_HOST_ALIAS to the
+  #    host alias to use as domain to enable this.
+  #    URL before:    s3.amazonaws.com/cdn.makigas.es/hi.css
+  #    URL after:     cdn.makigas.es/hi.css
+  #    S3_HOST_ALIAS is set to cdn.makigas.es. Usually this domain will
+  #    have a CNAME pointing to the bucket domain, although this block
+  #    won't care about it as the purpose here is to set the URLs.
+  if ENV['S3_BUCKET_DOMAIN'].present? || ENV['S3_HOST_ALIAS'].present?
+    Paperclip::Attachment.default_options[:path] = '/:class/:attachment/:id_partition/:style/:filename'
+    if ENV['S3_HOST_ALIAS'].present?
+      Paperclip::Attachment.default_options[:s3_host_alias] = ENV['S3_HOST_ALIAS']
+      Paperclip::Attachment.default_options[:url] = ':s3_alias_url'
+    else
+      Paperclip::Attachment.default_options[:url] = ':s3_domain_url'
+    end
+  end
+
+  # Use a custom endpoint (for instance, Minio or other S3-like APIs)
+  if ENV['S3_ENDPOINT'].present?
+    Paperclip::Attachment.default_options[:s3_region] = ENV.fetch('AWS_REGION') { 'us-east-1' }
+    Paperclip::Attachment.default_options[:s3_options] = {
+      force_path_style: true,
+      endpoint: ENV['S3_ENDPOINT']
+    }
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,10 +44,8 @@ services:
       DB_NAME: makigas
       DB_USERNAME: makigas
       DB_PASSWORD: makigas
-      S3_BUCKET_NAME: 'cdn.makigas.es'
-      S3_HOST_NAME: 's3-us-west-2.amazonaws.com'
-      S3_HOST_ALIAS: 'cdn.makigas.es'
-      S3_ENDPOINT: 'http://minio.danirod.es'
-      S3_BUCKET_DOMAIN: 'true'
-      AWS_ACCESS_KEY_ID: 25HVKL4CS60Z785UUQSX
-      AWS_SECRET_ACCESS_KEY: xLI8/Fa6yiWbdtZoQdchVXnhg86Xp2gm7H2gUxUp
+      S3_BUCKET_NAME: 'makigas'
+      S3_HOST_NAME: 'localhost:9000'
+      S3_ENDPOINT: 'http://storage:9000'
+      AWS_ACCESS_KEY_ID: 4j7anyzy
+      AWS_SECRET_ACCESS_KEY: NM8R5pozNkfHUgFNRx2Zxuxv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,16 @@ services:
       - '3000:3000'
     environment:
       RAILS_ENV: development
+      RAILS_USE_S3: 'true'
+      RAILS_LOG_TO_STDOUT: 'true'
       DB_HOST: database
       DB_NAME: makigas
       DB_USERNAME: makigas
       DB_PASSWORD: makigas
+      S3_BUCKET_NAME: 'cdn.makigas.es'
+      S3_HOST_NAME: 's3-us-west-2.amazonaws.com'
+      S3_HOST_ALIAS: 'cdn.makigas.es'
+      S3_ENDPOINT: 'http://minio.danirod.es'
+      S3_BUCKET_DOMAIN: 'true'
+      AWS_ACCESS_KEY_ID: 25HVKL4CS60Z785UUQSX
+      AWS_SECRET_ACCESS_KEY: xLI8/Fa6yiWbdtZoQdchVXnhg86Xp2gm7H2gUxUp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,18 @@ services:
     environment:
       POSTGRES_USER: 'makigas'
       POSTGRES_PASSWORD: 'makigas'
+  storage:
+    image: minio/minio
+    volumes:
+    - './docker_data/minio/data:/data'
+    - './docker_data/minio/config:/root/.minio'
+    ports:
+      - 9000:9000
+    environment:
+      # Randomly generated using KeePassXC. Do not use in production.
+      MINIO_ACCESS_KEY: 4j7anyzy
+      MINIO_SECRET_KEY: NM8R5pozNkfHUgFNRx2Zxuxv
+    command: server /data
   web:
     build: .
     image: danirod/makigas
@@ -17,6 +29,7 @@ services:
     restart: always
     depends_on:
       - database
+      - storage
     volumes:
     - '.:/makigas'
     - '/makigas/node_modules/'


### PR DESCRIPTION
This PR adds support for customizable file uploading into S3 and S3-like storage servers. Whenever a playlist, a topic or something that has a file field is saved, the uploaded file will be transfered into a different server for storage. A canonical URL is generated and when the browser downloads the web document, a full URL for accessing to the resource through the S3 public URL is provided to the user.

Currently Paperclip is storing thumbnails and cards into the file system by using the default uploader, using /var/www/makigas/current/public/system as the place where to save these data. However, there are a few advantages on using a storage server like S3 instead of the bare server. Just to name a few:

* Assets can be served through a CDN closer to the user.
* Assets can be served throught a cache server.
* Application is easier to move, since there are less files to care about.
* Assets can be served from a cookie-less domain, making requests faster.

To use S3 storage, the following environment variables are now defined. They must be provided to the application using a solution like dotenv, or a similar approach:

* `AWS_ACCESS_KEY_ID`: AWS access key. Keep it secret!
* `AWS_SECRET_KEY_ID`: AWS secret key. Keep it secret!
* `S3_BUCKET_NAME`: S3 bucket name where assets will be uploaded to and downloaded from, such as `cdn.makigas.es`.
* `AWS_REGION`: AWS region to use, such as `us-east-1`e or `eu-west-1`.

The following additional settings can be provided:
* `S3_HOST_NAME`: different S3 server name to use when providing assets to a browser, such as `s3-eu-west-1.amazonaws.com` instead of `s3.amazonaws.com`.
* `S3_BUCKET_DOMAIN`: if provided, the system will assume that the domain name used as S3_HOST_NAME contains the bucket name as a subdomain, such as `cdn.makigas.es.s3.amazonaws.com`, instead of `s3.amazonaws.com`. Asset URLs won't have the bucket name in their internal path, so instead of `s3.amazonaws.com/cdn.makigas.es/hello.css`, an asset will have the following URL: `cdn.makigas.es.s3.amazonaws.com/hello.css`.
* `S3_HOST_ALIAS`: custom domain to use to serve assets. If provided, asset URLs will use this host instead of the default `s3.amazonaws.com`. Additionally, it's assumed that there exists a S3 bucket with the same name as the host alias, because generated URLs won't contain the bucket name in their internal paths. So instead of `s3.amazonaws.com/cdn.makigas.es/hello.css`, the system will generate a URL like `cdn.makigas.es/hello.css`.

Additional settings for S3-like storage servers that are not S3 and that do not use the same endpoint:

* `S3_ENDPOINT`: if provided; create, update and delete requests for uploaded files will be sent to this endpoint server instead of `https://s3.amazonaws.com`.

A Minio instance is provided in the docker-compose.yml file to test this strategy.