### PR TITLE
Update factory_girl to factory_bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ end
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails', '~> 3.4'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'capybara'
   gem 'poltergeist'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,10 +94,10 @@ GEM
     erubi (1.7.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     ffi (1.9.18)
     friendly_id (5.2.3)
@@ -305,7 +305,7 @@ DEPENDENCIES
   capybara
   devise
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   friendly_id
   haml-rails (~> 1.0)
   jbuilder (~> 2.0)

--- a/spec/factories/opinions.rb
+++ b/spec/factories/opinions.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :opinion do
     from 'Programación & Co.'
     message 'Estamos encantados con el trabajo que hace este chico.'

--- a/spec/factories/playlists.rb
+++ b/spec/factories/playlists.rb
@@ -1,6 +1,6 @@
 include ActionDispatch::TestProcess
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :playlist do
     title 'Popular music videos'
     description 'This list contains a lot of musical videos'

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :topic do
     title 'Popular musics'
     description 'Popular musics of all kinds of styles and genres'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     email 'makigas@example.com'
     password '123456'

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :video do
     title 'Chandelier'
     description 'Music video for Chandelier'

--- a/spec/features/dashboard/opinions_spec.rb
+++ b/spec/features/dashboard/opinions_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature "Dashboard opinions", type: :feature do
   before { Capybara.default_host = "http://dashboard.example.com" }
   after { Capybara.default_host = "http://www.example.com" }
-  
+
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_opinions_path
@@ -13,12 +13,12 @@ RSpec.feature "Dashboard opinions", type: :feature do
 
   context "when logged in" do
     before(:each) {
-      @user = FactoryGirl.create(:user)
+      @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
     scenario "user can list the opinions" do
-      @opinion = FactoryGirl.create(:opinion)
+      @opinion = FactoryBot.create(:opinion)
       visit dashboard_opinions_path
       expect(page).to have_link @opinion.from, href: dashboard_opinion_path(@opinion)
     end
@@ -39,7 +39,7 @@ RSpec.feature "Dashboard opinions", type: :feature do
     end
 
     scenario "user can edit opinions" do
-      @opinion = FactoryGirl.create(:opinion, from: "Programming n Co")
+      @opinion = FactoryBot.create(:opinion, from: "Programming n Co")
 
       visit dashboard_opinions_path
       within(:xpath, "//tr[.//td//a[text() = 'Programming n Co']]") do
@@ -54,8 +54,8 @@ RSpec.feature "Dashboard opinions", type: :feature do
     end
 
     scenario "user can destroy opinions" do
-      @opinion = FactoryGirl.create(:opinion)
-      
+      @opinion = FactoryBot.create(:opinion)
+
       visit dashboard_opinions_path
       expect {
         within(:xpath, "//tr[.//td//a[text() = '#{@opinion.from}']]") do

--- a/spec/features/dashboard/playlist_videos_spec.rb
+++ b/spec/features/dashboard/playlist_videos_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.feature "Dashboard playlist videos", type: :feature do
   before { Capybara.default_host = "http://dashboard.example.com" }
   after { Capybara.default_host = "http://www.example.com" }
-  
+
   before(:each) {
-    @playlist = FactoryGirl.create(:playlist)
+    @playlist = FactoryBot.create(:playlist)
     @videos = [
-      FactoryGirl.create(:video, playlist: @playlist, title: 'Primero', position: 1, youtube_id: '1'),
-      FactoryGirl.create(:video, playlist: @playlist, title: 'Segundo', position: 2, youtube_id: '2')
+      FactoryBot.create(:video, playlist: @playlist, title: 'Primero', position: 1, youtube_id: '1'),
+      FactoryBot.create(:video, playlist: @playlist, title: 'Segundo', position: 2, youtube_id: '2')
     ]
   }
 
@@ -21,7 +21,7 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
 
   context "when logged in" do
     before(:each) {
-      @user = FactoryGirl.create(:user)
+      @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 

--- a/spec/features/dashboard/playlists_spec.rb
+++ b/spec/features/dashboard/playlists_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature "Dashboard playlists", type: :feature do
   before { Capybara.default_host = "http://dashboard.example.com" }
   after { Capybara.default_host = "http://www.example.com" }
-  
+
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_playlists_path
@@ -13,13 +13,13 @@ RSpec.feature "Dashboard playlists", type: :feature do
 
   context "when logged in" do
     before(:each) {
-      @user = FactoryGirl.create(:user)
+      @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
     scenario "user can list the playlists" do
-      @playlist = FactoryGirl.create(:playlist)
-      @video = FactoryGirl.create(:video, playlist: @playlist)
+      @playlist = FactoryBot.create(:playlist)
+      @video = FactoryBot.create(:video, playlist: @playlist)
 
       visit dashboard_playlists_path
       expect(page).to have_link @playlist.title, href: dashboard_playlist_path(@playlist)
@@ -43,7 +43,7 @@ RSpec.feature "Dashboard playlists", type: :feature do
     end
 
     scenario "user can attach a playlist to a topic" do
-      @topic = FactoryGirl.create(:topic)
+      @topic = FactoryBot.create(:topic)
 
       visit dashboard_playlists_path
       click_link "Nueva Lista"
@@ -60,7 +60,7 @@ RSpec.feature "Dashboard playlists", type: :feature do
     end
 
     scenario "user can edit a playlist" do
-      @playlist = FactoryGirl.create(:playlist, title: 'My old title')
+      @playlist = FactoryBot.create(:playlist, title: 'My old title')
 
       visit dashboard_playlists_path
       within(:xpath, "//tr[.//td//a[text() = 'My old title']]") do
@@ -76,8 +76,8 @@ RSpec.feature "Dashboard playlists", type: :feature do
     end
 
     scenario "user can destroy a playlist" do
-      @playlist = FactoryGirl.create(:playlist)
-      
+      @playlist = FactoryBot.create(:playlist)
+
       visit dashboard_playlists_path
       expect {
         within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do

--- a/spec/features/dashboard/topics_spec.rb
+++ b/spec/features/dashboard/topics_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature "Dashboard topics", type: :feature do
   before { Capybara.default_host = "http://dashboard.example.com" }
   after { Capybara.default_host = "http://www.example.com" }
-  
+
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_topics_path
@@ -13,13 +13,13 @@ RSpec.feature "Dashboard topics", type: :feature do
 
   context "when logged in" do
     before(:each) {
-      @user = FactoryGirl.create(:user)
+      @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
     scenario "user can list the topics" do
-      @topic = FactoryGirl.create(:topic)
-      @playlist = FactoryGirl.create(:playlist, topic: @topic)
+      @topic = FactoryBot.create(:topic)
+      @playlist = FactoryBot.create(:playlist, topic: @topic)
 
       visit dashboard_topics_path
       expect(page).to have_link @topic.title, href: dashboard_topic_path(@topic)
@@ -44,7 +44,7 @@ RSpec.feature "Dashboard topics", type: :feature do
     end
 
     scenario "user can edit topics" do
-      @topic = FactoryGirl.create(:topic, title: "My old title")
+      @topic = FactoryBot.create(:topic, title: "My old title")
 
       visit dashboard_topics_path
       within(:xpath, "//tr[.//td//a[text() = 'My old title']]") do
@@ -59,9 +59,9 @@ RSpec.feature "Dashboard topics", type: :feature do
     end
 
     scenario "user can destroy topics" do
-      @topic = FactoryGirl.create(:topic)
-      @playlist = FactoryGirl.create(:playlist, topic: @topic)
-      
+      @topic = FactoryBot.create(:topic)
+      @playlist = FactoryBot.create(:playlist, topic: @topic)
+
       visit dashboard_topics_path
       expect {
         within(:xpath, "//tr[.//td//a[text() = '#{@topic.title}']]") do

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -20,19 +20,19 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
 
   context "when logged in" do
     before(:each) {
-      @user = FactoryGirl.create(:user)
+      @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
     scenario "user can list videos" do
-      @video = FactoryGirl.create(:video)
+      @video = FactoryBot.create(:video)
       visit dashboard_videos_path
       expect(page).to have_link @video.title
     end
 
     scenario "user can create videos" do
-      @playlist = FactoryGirl.create(:playlist)
-      
+      @playlist = FactoryBot.create(:playlist)
+
       visit dashboard_videos_path
       expect {
         click_link 'Nuevo Vídeo'
@@ -50,9 +50,9 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
     end
 
     scenario "user can set the duration of a video" do
-      @playlist = FactoryGirl.create(:playlist)
+      @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
-      
+
       click_link 'Nuevo Vídeo'
       fill_in 'Título', with: 'My video title'
       fill_in 'Descripción', with: 'This is a long video'
@@ -68,7 +68,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
     end
 
     scenario "user can create unfeatured videos" do
-      @playlist = FactoryGirl.create(:playlist)
+      @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
 
       expect {
@@ -92,7 +92,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
     end
 
     scenario "user cannot create videos with invalid data" do
-      @playlist = FactoryGirl.create(:playlist)
+      @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
       expect {
         click_link 'Nuevo Vídeo'
@@ -119,7 +119,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
     end
 
     scenario "user can edit videos" do
-      @video = FactoryGirl.create(:video, title: 'My old video')
+      @video = FactoryBot.create(:video, title: 'My old video')
 
       visit dashboard_videos_path
       within(:xpath, "//tr[.//a[text() = 'My old video']]") do
@@ -132,7 +132,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
     end
 
     scenario "user can destroy videos" do
-      @video = FactoryGirl.create(:video, title: 'My cool video')
+      @video = FactoryBot.create(:video, title: 'My cool video')
 
       visit dashboard_videos_path
       expect {

--- a/spec/features/front/front_opinions_spec.rb
+++ b/spec/features/front/front_opinions_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Front opinions', type: :feature do
-  let!(:opinion) { FactoryGirl.create(:opinion) }
+  let!(:opinion) { FactoryBot.create(:opinion) }
 
   scenario 'displays link' do
     visit root_path

--- a/spec/features/front/front_videos_spec.rb
+++ b/spec/features/front/front_videos_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature "Videos listed in front page", type: :feature do
-  let!(:video) { FactoryGirl.create(:video) }
+  let!(:video) { FactoryBot.create(:video) }
 
   scenario 'displays thumbnail' do
       visit root_path
@@ -18,7 +18,7 @@ RSpec.feature "Videos listed in front page", type: :feature do
   end
 
   scenario "doesn't show videos hidden from front" do
-    hidden = FactoryGirl.create(:video, title: 'Hidden', youtube_id: 'AABBCC', unfeatured: true)
+    hidden = FactoryBot.create(:video, title: 'Hidden', youtube_id: 'AABBCC', unfeatured: true)
     visit root_path
     within '.recent-videos' do
       expect(page).to have_link video.title
@@ -27,9 +27,9 @@ RSpec.feature "Videos listed in front page", type: :feature do
   end
 
   scenario "doesn't show videos not yet published" do
-    scheduled = FactoryGirl.create(:tomorrow_video, youtube_id: 'TOMORROW', title: 'Scheduled one')
-    published = FactoryGirl.create(:yesterday_video, youtube_id: 'YESTERDAY', title: 'This is published')
-    
+    scheduled = FactoryBot.create(:tomorrow_video, youtube_id: 'TOMORROW', title: 'Scheduled one')
+    published = FactoryBot.create(:yesterday_video, youtube_id: 'YESTERDAY', title: 'This is published')
+
     visit root_path
     within '.recent-videos' do
       expect(page).to have_link published.title

--- a/spec/features/playlists/playlist_page_spec.rb
+++ b/spec/features/playlists/playlist_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature "Playlist page", type: :feature do
-  before { @playlist = FactoryGirl.create(:playlist) }
+  before { @playlist = FactoryBot.create(:playlist) }
 
   scenario 'displays playlist information' do
     visit playlist_path(@playlist)
@@ -12,7 +12,7 @@ RSpec.feature "Playlist page", type: :feature do
   end
 
   scenario 'displays information about videos in this playlist' do
-    @video = FactoryGirl.create(:video, playlist: @playlist, duration: 133)
+    @video = FactoryBot.create(:video, playlist: @playlist, duration: 133)
 
     visit playlist_path(@playlist)
 
@@ -23,8 +23,8 @@ RSpec.feature "Playlist page", type: :feature do
   end
 
   scenario 'scheduled videos are not displayed' do
-    @published = FactoryGirl.create(:yesterday_video, playlist: @playlist, title: 'Yesterday', youtube_id: 'YESTERDAY')
-    @scheduled = FactoryGirl.create(:tomorrow_video, playlist: @playlist, title: 'Tomorrow', youtube_id: 'TOMORROW')
+    @published = FactoryBot.create(:yesterday_video, playlist: @playlist, title: 'Yesterday', youtube_id: 'YESTERDAY')
+    @scheduled = FactoryBot.create(:tomorrow_video, playlist: @playlist, title: 'Tomorrow', youtube_id: 'TOMORROW')
 
     visit playlist_path(@playlist)
 

--- a/spec/features/playlists/playlists_page_spec.rb
+++ b/spec/features/playlists/playlists_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature "Playlists page", type: :feature do
-  before { @playlist = FactoryGirl.create(:playlist) }
+  before { @playlist = FactoryBot.create(:playlist) }
 
   scenario 'displays information about playlists' do
     visit playlists_path
@@ -18,7 +18,7 @@ RSpec.feature "Playlists page", type: :feature do
     end
 
     scenario 'single video' do
-      FactoryGirl.create(:video, playlist: @playlist)
+      FactoryBot.create(:video, playlist: @playlist)
 
       visit playlists_path
 
@@ -26,8 +26,8 @@ RSpec.feature "Playlists page", type: :feature do
     end
 
     scenario 'many videos' do
-      FactoryGirl.create(:video, playlist: @playlist, youtube_id: '1234')
-      FactoryGirl.create(:video, playlist: @playlist, youtube_id: '1238')
+      FactoryBot.create(:video, playlist: @playlist, youtube_id: '1234')
+      FactoryBot.create(:video, playlist: @playlist, youtube_id: '1238')
 
       visit playlists_path
 
@@ -35,8 +35,8 @@ RSpec.feature "Playlists page", type: :feature do
     end
 
     scenario 'scheduled videos are not counted' do
-      FactoryGirl.create(:video, playlist: @playlist, youtube_id: '1234')
-      FactoryGirl.create(:tomorrow_video, playlist: @playlist, youtube_id: '1238')
+      FactoryBot.create(:video, playlist: @playlist, youtube_id: '1234')
+      FactoryBot.create(:tomorrow_video, playlist: @playlist, youtube_id: '1238')
 
       visit playlists_path
 

--- a/spec/features/topics/topic_page_spec.rb
+++ b/spec/features/topics/topic_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature "Topic page", type: :feature do
-  before { @topic = FactoryGirl.create(:topic) }
+  before { @topic = FactoryBot.create(:topic) }
 
   scenario 'shows information about a topic' do
     visit topic_path(@topic)
@@ -11,7 +11,7 @@ RSpec.feature "Topic page", type: :feature do
   end
 
   scenario 'shows playlists in a topic' do
-    @playlist = FactoryGirl.create(:playlist, topic: @topic)
+    @playlist = FactoryBot.create(:playlist, topic: @topic)
 
     visit topic_path(@topic)
 
@@ -22,7 +22,7 @@ RSpec.feature "Topic page", type: :feature do
 
   context 'on empty playlists' do
     before do
-      @playlist = FactoryGirl.create(:playlist, topic: @topic)
+      @playlist = FactoryBot.create(:playlist, topic: @topic)
     end
 
     scenario 'shows the playlist length' do
@@ -33,8 +33,8 @@ RSpec.feature "Topic page", type: :feature do
 
   context 'on playlists with a single video' do
     before do
-      @playlist = FactoryGirl.create(:playlist, topic: @topic)
-      FactoryGirl.create(:video, playlist: @playlist)
+      @playlist = FactoryBot.create(:playlist, topic: @topic)
+      FactoryBot.create(:video, playlist: @playlist)
 
       scenario 'shows the playlist length' do
         visit topic_path(@topic)
@@ -45,9 +45,9 @@ RSpec.feature "Topic page", type: :feature do
 
   context 'on playlists with many videos' do
     before do
-      @playlist = FactoryGirl.create(:playlist, topic: @topic)
-      FactoryGirl.create(:video, playlist: @playlist, youtube_id: '1234')
-      FactoryGirl.create(:video, playlist: @playlist, youtube_id: '1235')
+      @playlist = FactoryBot.create(:playlist, topic: @topic)
+      FactoryBot.create(:video, playlist: @playlist, youtube_id: '1234')
+      FactoryBot.create(:video, playlist: @playlist, youtube_id: '1235')
     end
 
     scenario 'shows the playlist length' do
@@ -58,9 +58,9 @@ RSpec.feature "Topic page", type: :feature do
 
   context 'on playlists with scheduled videos' do
     before do
-      @playlist = FactoryGirl.create(:playlist, topic: @topic)
-      FactoryGirl.create(:video, playlist: @playlist, youtube_id: '1234')
-      FactoryGirl.create(:video, playlist: @playlist, youtube_id: '1235', published_at: 2.days.from_now)
+      @playlist = FactoryBot.create(:playlist, topic: @topic)
+      FactoryBot.create(:video, playlist: @playlist, youtube_id: '1234')
+      FactoryBot.create(:video, playlist: @playlist, youtube_id: '1235', published_at: 2.days.from_now)
     end
 
     scenario 'scheduled videos are not counted' do

--- a/spec/features/topics/topics_page_spec.rb
+++ b/spec/features/topics/topics_page_spec.rb
@@ -7,10 +7,10 @@ RSpec.feature "Topics page", type: :feature do
       expect(page.status_code).to be 200
     end
   end
-  
+
   context "when there are topics" do
     before(:each) {
-      @topic = FactoryGirl.create(:topic)
+      @topic = FactoryBot.create(:topic)
     }
 
     it "it is success" do

--- a/spec/features/videos/video_page_spec.rb
+++ b/spec/features/videos/video_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature "Video page", type: :feature do
-  before { @video = FactoryGirl.create(:video, duration: 133) }
+  before { @video = FactoryBot.create(:video, duration: 133) }
 
   scenario 'there is information about the video' do
     visit_video @video
@@ -31,7 +31,7 @@ RSpec.feature "Video page", type: :feature do
 
   context 'a topic has been assigned' do
     before do
-      @topic = FactoryGirl.create(:topic)
+      @topic = FactoryBot.create(:topic)
       @video.playlist.update_attributes(topic: @topic)
     end
 
@@ -81,7 +81,7 @@ RSpec.feature "Video page", type: :feature do
 
     context 'a topic has been assigned' do
       before do
-        @topic = FactoryGirl.create(:topic)
+        @topic = FactoryBot.create(:topic)
         @video.playlist.update_attributes(topic: @topic)
       end
 
@@ -106,7 +106,7 @@ RSpec.feature "Video page", type: :feature do
 
     context 'user is logged in' do
       before do
-        @user = FactoryGirl.create(:user)
+        @user = FactoryBot.create(:user)
         login_as @user, scope: :user
       end
 

--- a/spec/features/videos/videos_page_spec.rb
+++ b/spec/features/videos/videos_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Topics page", type: :feature do
   end
 
   scenario "displays information about videos" do
-    video = FactoryGirl.create(:video, duration: 133)
+    video = FactoryBot.create(:video, duration: 133)
 
     visit videos_path
     expect(page).to have_link video.title, href: playlist_video_path(video, playlist_id: video.playlist)
@@ -17,17 +17,17 @@ RSpec.feature "Topics page", type: :feature do
   end
 
   scenario "displays topic if the playlist has one" do
-    topic = FactoryGirl.create(:topic)
-    playlist = FactoryGirl.create(:playlist, topic: topic)
-    video = FactoryGirl.create(:video, playlist: playlist)
-    
+    topic = FactoryBot.create(:topic)
+    playlist = FactoryBot.create(:playlist, topic: topic)
+    video = FactoryBot.create(:video, playlist: playlist)
+
     visit videos_path
     expect(page).to have_link topic.title, href: topic_path(topic)
   end
 
   scenario "scheduled videos are not displayed" do
-    published = FactoryGirl.create(:yesterday_video, youtube_id: 'PUBLISHED', title: 'Published')
-    scheduled = FactoryGirl.create(:tomorrow_video, youtube_id: 'TOMORROW', title: 'Scheduled')
+    published = FactoryBot.create(:yesterday_video, youtube_id: 'PUBLISHED', title: 'Published')
+    scheduled = FactoryBot.create(:tomorrow_video, youtube_id: 'TOMORROW', title: 'Scheduled')
 
     visit videos_path
     expect(page).to have_text published.title

--- a/spec/features/videos/videos_search_spec.rb
+++ b/spec/features/videos/videos_search_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.feature "Videos search", type: :feature do
   context "searching by length" do
     before(:each) do
-      @short = FactoryGirl.create(:video, duration: 200, title: 'Short', youtube_id: '1')
-      @medium = FactoryGirl.create(:video, duration: 600, title: 'Medium', youtube_id: '2')
-      @long = FactoryGirl.create(:video, duration: 1200, title: 'Long', youtube_id: '3')
+      @short = FactoryBot.create(:video, duration: 200, title: 'Short', youtube_id: '1')
+      @medium = FactoryBot.create(:video, duration: 600, title: 'Medium', youtube_id: '2')
+      @long = FactoryBot.create(:video, duration: 1200, title: 'Long', youtube_id: '3')
     end
-    
+
     scenario "can search for short length videos" do
       visit videos_path
       choose 'Cortos'
@@ -38,12 +38,12 @@ RSpec.feature "Videos search", type: :feature do
 
   context "searching by topic" do
     before(:each) do
-      @topic1 = FactoryGirl.create(:topic, title: 'First Topic')
-      @topic2 = FactoryGirl.create(:topic, title: 'Second Topic')
-      @playlist1 = FactoryGirl.create(:playlist, topic: @topic1)
-      @playlist2 = FactoryGirl.create(:playlist, topic: @topic2)
-      @video1 = FactoryGirl.create(:video, title: 'First', youtube_id: 'A', playlist: @playlist1)
-      @video2 = FactoryGirl.create(:video, title: 'Second', youtube_id: 'B', playlist: @playlist2)
+      @topic1 = FactoryBot.create(:topic, title: 'First Topic')
+      @topic2 = FactoryBot.create(:topic, title: 'Second Topic')
+      @playlist1 = FactoryBot.create(:playlist, topic: @topic1)
+      @playlist2 = FactoryBot.create(:playlist, topic: @topic2)
+      @video1 = FactoryBot.create(:video, title: 'First', youtube_id: 'A', playlist: @playlist1)
+      @video2 = FactoryBot.create(:video, title: 'Second', youtube_id: 'B', playlist: @playlist2)
     end
 
     scenario "can search for videos in a topic" do

--- a/spec/helpers/dashboard/videos_helper_spec.rb
+++ b/spec/helpers/dashboard/videos_helper_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::VideosHelper, type: :helper do
-  before(:each) { @video = FactoryGirl.create(:video) }
-  
+  before(:each) { @video = FactoryBot.create(:video) }
+
   context 'dashboard_video' do
     it { expect(dashboard_video_path @video).to eq dashboard_playlist_video_path(@video, playlist_id: @video.playlist) }
     it { expect(dashboard_video_url @video).to eq dashboard_playlist_video_url(@video, playlist_id: @video.playlist) }

--- a/spec/helpers/videos_helper_spec.rb
+++ b/spec/helpers/videos_helper_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe VideosHelper, type: :helper do
   it 'should get video path' do
-    video = FactoryGirl.create(:video)
+    video = FactoryBot.create(:video)
     expect(video_path(video)).to eq playlist_video_path(video, playlist_id: video.playlist)
   end
 
   it 'should get video URL' do
-    video = FactoryGirl.create(:video)
+    video = FactoryBot.create(:video)
     expect(video_url(video)).to eq playlist_video_url(video, playlist_id: video.playlist)
   end
 end

--- a/spec/models/opinion_spec.rb
+++ b/spec/models/opinion_spec.rb
@@ -1,30 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Opinion, type: :model do
-  
+
   it 'has a valid factory' do
-    opinion = FactoryGirl.build(:opinion)
+    opinion = FactoryBot.build(:opinion)
     expect(opinion).to be_valid
   end
-  
+
   context 'validation' do
     it 'is not valid without a name from' do
-      opinion = FactoryGirl.build(:opinion, from: nil)
+      opinion = FactoryBot.build(:opinion, from: nil)
       expect(opinion).not_to be_valid
     end
 
     it 'is not valid without a message' do
-      opinion = FactoryGirl.build(:opinion, message: nil)
+      opinion = FactoryBot.build(:opinion, message: nil)
       expect(opinion).not_to be_valid
     end
 
     it 'is valid without an URL' do
-      opinion = FactoryGirl.build(:opinion, url: nil)
+      opinion = FactoryBot.build(:opinion, url: nil)
       expect(opinion).to be_valid
     end
 
     it 'is not valid without a photo' do
-      opinion = FactoryGirl.build(:opinion, photo: nil)
+      opinion = FactoryBot.build(:opinion, photo: nil)
       expect(opinion).not_to be_valid
     end
   end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -3,83 +3,83 @@ require 'rails_helper'
 RSpec.describe Playlist, type: :model do
 
   it 'has a valid factory' do
-    playlist = FactoryGirl.build(:playlist)
+    playlist = FactoryBot.build(:playlist)
     expect(playlist).to be_valid
   end
 
   context 'validation' do
     it 'is not valid without title' do
-      playlist = FactoryGirl.build(:playlist, title: nil)
+      playlist = FactoryBot.build(:playlist, title: nil)
       expect(playlist).not_to be_valid
     end
 
     it 'is not valid with a long title' do
-      playlist = FactoryGirl.build(:playlist, title: 'A' * 101)
+      playlist = FactoryBot.build(:playlist, title: 'A' * 101)
       expect(playlist).not_to be_valid
     end
 
     it 'is not valid without description' do
-      playlist = FactoryGirl.build(:playlist, description: nil)
+      playlist = FactoryBot.build(:playlist, description: nil)
       expect(playlist).not_to be_valid
     end
 
     it 'is not valid with a long description' do
-      playlist = FactoryGirl.build(:playlist, description: 'A' * 5001)
+      playlist = FactoryBot.build(:playlist, description: 'A' * 5001)
       expect(playlist).not_to be_valid
     end
 
     it 'is not valid without YouTube ID' do
-      playlist = FactoryGirl.build(:playlist, youtube_id: nil)
+      playlist = FactoryBot.build(:playlist, youtube_id: nil)
       expect(playlist).not_to be_valid
     end
 
     it 'is not valid with a long YouTube ID' do
-      playlist = FactoryGirl.build(:playlist, youtube_id: 'A' * 101)
+      playlist = FactoryBot.build(:playlist, youtube_id: 'A' * 101)
       expect(playlist).not_to be_valid
     end
 
     it 'is not valid without a card' do
-      playlist = FactoryGirl.build(:playlist, card: nil)
+      playlist = FactoryBot.build(:playlist, card: nil)
       expect(playlist).not_to be_valid
     end
 
     it 'is not valid without a playlist photo' do
-      playlist = FactoryGirl.build(:playlist, thumbnail: nil)
+      playlist = FactoryBot.build(:playlist, thumbnail: nil)
       expect(playlist).not_to be_valid
     end
 
     it 'is valid without a topic' do
-      playlist = FactoryGirl.build(:playlist, topic: nil)
+      playlist = FactoryBot.build(:playlist, topic: nil)
       expect(playlist).to be_valid
     end
   end
 
   context 'videos association' do
     it 'reports total length' do
-      playlist = FactoryGirl.build(:playlist)
-      video1 = FactoryGirl.create(:video, youtube_id: '12345', duration: 60, playlist: playlist)
-      video2 = FactoryGirl.create(:video, youtube_id: '12346', duration: 90, playlist: playlist)
+      playlist = FactoryBot.build(:playlist)
+      video1 = FactoryBot.create(:video, youtube_id: '12345', duration: 60, playlist: playlist)
+      video2 = FactoryBot.create(:video, youtube_id: '12346', duration: 90, playlist: playlist)
       expect(playlist.total_length).to eq 150
     end
   end
 
   context 'slug' do
     it 'generates a valid slug' do
-      playlist = FactoryGirl.create(:playlist, title: 'Sample')
+      playlist = FactoryBot.create(:playlist, title: 'Sample')
       expect(playlist.slug).to eq 'sample'
     end
   end
-  
+
   context 'topic association' do
     it 'may belong to a topic' do
-      playlist = FactoryGirl.create(:playlist)
+      playlist = FactoryBot.create(:playlist)
       expect(playlist).to respond_to(:topic)
     end
   end
 
   context 'videos association' do
     it 'has many videos' do
-      playlist = FactoryGirl.create(:playlist)
+      playlist = FactoryBot.create(:playlist)
       expect(playlist).to respond_to(:videos)
     end
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3,59 +3,59 @@ require 'rails_helper'
 RSpec.describe Topic, type: :model do
 
   it 'has a valid factory' do
-    topic = FactoryGirl.build(:topic)
+    topic = FactoryBot.build(:topic)
     expect(topic).to be_valid
   end
 
   context 'model' do
     it 'is not valid without a title' do
-      topic = FactoryGirl.build(:topic, title: nil)
+      topic = FactoryBot.build(:topic, title: nil)
       expect(topic).not_to be_valid
     end
 
     it 'is not valid with a title longer than 50 characters' do
-      topic = FactoryGirl.build(:topic, title: 'A' * 51)
+      topic = FactoryBot.build(:topic, title: 'A' * 51)
       expect(topic).not_to be_valid
     end
 
     it 'is not valid without a description' do
-      topic = FactoryGirl.build(:topic, description: nil)
+      topic = FactoryBot.build(:topic, description: nil)
       expect(topic).not_to be_valid
     end
 
     it 'is not valid without a description longer than 250 characters' do
-      topic = FactoryGirl.build(:topic, description: 'A' * 251)
+      topic = FactoryBot.build(:topic, description: 'A' * 251)
       expect(topic).not_to be_valid
     end
 
     it 'is not valid without a thumbnail' do
-      topic = FactoryGirl.build(:topic, thumbnail: nil)
+      topic = FactoryBot.build(:topic, thumbnail: nil)
       expect(topic).not_to be_valid
     end
 
     it 'is not valid without color' do
-      topic = FactoryGirl.build(:topic, color: nil)
+      topic = FactoryBot.build(:topic, color: nil)
       expect(topic).not_to be_valid
     end
   end
 
   context 'slug' do
     it 'generates a slug' do
-      topic = FactoryGirl.create(:topic, title: 'My topic')
+      topic = FactoryBot.create(:topic, title: 'My topic')
       expect(topic.slug).to eq 'my-topic'
     end
   end
 
   context 'playlists association' do
     it 'should have playlists' do
-      topic = FactoryGirl.create(:topic)
-      playlist = FactoryGirl.create(:playlist, topic: topic)
+      topic = FactoryBot.create(:topic)
+      playlist = FactoryBot.create(:playlist, topic: topic)
       expect(topic).to respond_to(:playlists)
     end
 
     it 'should nullify its playlists when removed' do
-      topic = FactoryGirl.create(:topic)
-      playlist = FactoryGirl.create(:playlist, topic: topic)
+      topic = FactoryBot.create(:topic)
+      playlist = FactoryBot.create(:playlist, topic: topic)
       topic.destroy
       playlist.reload
       expect(playlist.topic).to eq nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,24 +3,24 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
 
   it 'has a valid factory' do
-    user = FactoryGirl.build(:user)
+    user = FactoryBot.build(:user)
     expect(user).to be_valid
   end
 
   context 'validation' do
     it 'is not valid without e-mail' do
-      user = FactoryGirl.build(:user, email: nil)
+      user = FactoryBot.build(:user, email: nil)
       expect(user).not_to be_valid
     end
 
     it 'is not valid without a password' do
-      user = FactoryGirl.build(:user, password: nil)
+      user = FactoryBot.build(:user, password: nil)
       expect(user).not_to be_valid
     end
-    
+
     it 'is not valid if the e-mail is already present' do
-      user1 = FactoryGirl.create(:user, email: 'email1@example.com')
-      user2 = FactoryGirl.build(:user, email: 'email1@example.com')
+      user1 = FactoryBot.create(:user, email: 'email1@example.com')
+      user2 = FactoryBot.build(:user, email: 'email1@example.com')
       expect(user2).not_to be_valid
     end
   end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -3,74 +3,74 @@ require 'rails_helper'
 RSpec.describe Video, type: :model do
   context 'is valid when instanciated via' do
     it ':video factory' do
-      video = FactoryGirl.build(:video)
+      video = FactoryBot.build(:video)
       expect(video).to be_valid
     end
 
     it ':yesterday_video factory' do
-      video = FactoryGirl.build(:yesterday_video)
+      video = FactoryBot.build(:yesterday_video)
       expect(video).to be_valid
     end
 
     it ':tomorrow_video factory' do
-      video = FactoryGirl.build(:tomorrow_video)
+      video = FactoryBot.build(:tomorrow_video)
       expect(video).to be_valid
     end
   end
 
   context 'validation' do
     it 'is not valid without title' do
-      video = FactoryGirl.build(:video, title: nil)
+      video = FactoryBot.build(:video, title: nil)
       expect(video).not_to be_valid
     end
 
     it 'is not valid with a long title' do
-      video = FactoryGirl.build(:video, title: 'A' * 101)
+      video = FactoryBot.build(:video, title: 'A' * 101)
       expect(video).not_to be_valid
     end
 
     it 'is not valid without description' do
-      video = FactoryGirl.build(:video, description: nil)
+      video = FactoryBot.build(:video, description: nil)
       expect(video).not_to be_valid
     end
 
     it 'is not valid without a long description' do
-      video = FactoryGirl.build(:video, description: 'A' * 1501)
+      video = FactoryBot.build(:video, description: 'A' * 1501)
       expect(video).not_to be_valid
     end
 
     it 'is not valid without YouTube ID' do
-      video = FactoryGirl.build(:video, youtube_id: nil)
+      video = FactoryBot.build(:video, youtube_id: nil)
       expect(video).not_to be_valid
     end
 
     it 'is not valid with a long YouTube ID' do
-      video = FactoryGirl.build(:video, youtube_id: 'A' * 16)
+      video = FactoryBot.build(:video, youtube_id: 'A' * 16)
       expect(video).not_to be_valid
     end
 
     it 'is not valid without duration' do
-      video = FactoryGirl.build(:video, duration: nil)
+      video = FactoryBot.build(:video, duration: nil)
       expect(video).not_to be_valid
     end
 
     it 'is not valid with zero duration' do
-      video = FactoryGirl.build(:video, duration: 0)
+      video = FactoryBot.build(:video, duration: 0)
       expect(video).not_to be_valid
     end
 
     it 'is not valid with negative duration' do
-      video = FactoryGirl.build(:video, duration: -1)
+      video = FactoryBot.build(:video, duration: -1)
       expect(video).not_to be_valid
     end
 
     it 'is not valid without being in a playlist' do
-      video = FactoryGirl.build(:video, playlist: nil)
+      video = FactoryBot.build(:video, playlist: nil)
       expect(video).not_to be_valid
     end
 
     it 'is not valid without a publishing date' do
-      video = FactoryGirl.build(:video, published_at: nil)
+      video = FactoryBot.build(:video, published_at: nil)
       expect(video).not_to be_valid
     end
 
@@ -80,39 +80,39 @@ RSpec.describe Video, type: :model do
 
   context 'slug' do
     it 'generates slug' do
-      video = FactoryGirl.create(:video, title: 'Sample')
+      video = FactoryBot.create(:video, title: 'Sample')
       expect(video.slug).to eq 'sample'
     end
 
     it 'does not repeat slug' do
-      playlist = FactoryGirl.create(:playlist)
-      video1 = FactoryGirl.create(:video, title: 'Sample', playlist: playlist)
-      video2 = FactoryGirl.create(:video, title: 'Sample', youtube_id: 'AAAA', playlist: playlist)
+      playlist = FactoryBot.create(:playlist)
+      video1 = FactoryBot.create(:video, title: 'Sample', playlist: playlist)
+      video2 = FactoryBot.create(:video, title: 'Sample', youtube_id: 'AAAA', playlist: playlist)
       expect(video1.slug).not_to eq video2.slug
     end
 
     it 'repeats slug on different playlists' do
-      video1 = FactoryGirl.create(:video, title: 'Sample', youtube_id: 'AAAA')
-      playlist2 = FactoryGirl.create(:playlist, title: 'Hello')
-      video2 = FactoryGirl.create(:video, title: 'Sample', playlist: playlist2)
+      video1 = FactoryBot.create(:video, title: 'Sample', youtube_id: 'AAAA')
+      playlist2 = FactoryBot.create(:playlist, title: 'Hello')
+      video2 = FactoryBot.create(:video, title: 'Sample', playlist: playlist2)
       expect(video1.slug).to eq video2.slug
     end
   end
 
   context 'natural duration' do
     it 'should convert from duration to natural duration' do
-      expect(FactoryGirl.build(:video, duration: 12).natural_duration).
+      expect(FactoryBot.build(:video, duration: 12).natural_duration).
         to eq '00:00:12'
-      expect(FactoryGirl.build(:video, duration: 61).natural_duration).
+      expect(FactoryBot.build(:video, duration: 61).natural_duration).
         to eq '00:01:01'
-      expect(FactoryGirl.build(:video, duration: 102).natural_duration).
+      expect(FactoryBot.build(:video, duration: 102).natural_duration).
         to eq '00:01:42'
-      expect(FactoryGirl.build(:video, duration: 3600).natural_duration).
+      expect(FactoryBot.build(:video, duration: 3600).natural_duration).
         to eq '01:00:00'
     end
 
     it 'should convert from natural duration to duration' do
-      video = FactoryGirl.build(:video)
+      video = FactoryBot.build(:video)
       video.natural_duration = '0:12'
       expect(video.duration).to eq 12
       video.natural_duration = '1:01'
@@ -131,8 +131,8 @@ RSpec.describe Video, type: :model do
   end
 
   describe '.visible?' do
-    let(:published) { FactoryGirl.build(:video, published_at: 2.days.ago) }
-    let(:scheduled) { FactoryGirl.build(:video, published_at: 6.weeks.from_now) }
+    let(:published) { FactoryBot.build(:video, published_at: 2.days.ago) }
+    let(:scheduled) { FactoryBot.build(:video, published_at: 6.weeks.from_now) }
 
     context 'when publishing date has been reached' do
       subject { published.visible? }
@@ -146,8 +146,8 @@ RSpec.describe Video, type: :model do
   end
 
   describe '.scheduled?' do
-    let(:published) { FactoryGirl.build(:video, published_at: 2.days.ago) }
-    let(:scheduled) { FactoryGirl.build(:video, published_at: 6.weeks.from_now) }
+    let(:published) { FactoryBot.build(:video, published_at: 2.days.ago) }
+    let(:scheduled) { FactoryBot.build(:video, published_at: 6.weeks.from_now) }
 
     context 'when publishing date has been reached' do
       subject { published.scheduled? }
@@ -162,8 +162,8 @@ RSpec.describe Video, type: :model do
 
   describe '.visible' do
     before(:each) do
-      @published = FactoryGirl.create(:video, youtube_id: 'ASDF', published_at: 2.days.ago)
-      @scheduled = FactoryGirl.create(:video, youtube_id: 'ASDQ', published_at: 2.days.from_now)
+      @published = FactoryBot.create(:video, youtube_id: 'ASDF', published_at: 2.days.ago)
+      @scheduled = FactoryBot.create(:video, youtube_id: 'ASDQ', published_at: 2.days.from_now)
     end
 
     it 'should contain a video published yesterday' do


### PR DESCRIPTION
FactoryGirl is now known as FactoryBot. This is just a rename, not a new library. Reasons documented [here](https://robots.thoughtbot.com/factory_bot) and on thoughtbot/factory_bot#921. This PR replaces the gem name and also replaces ocurrences of FactoryGirl and factory_girl tokens with their new names.