### PR TITLE
Add ATOM syndication feeds to the site

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -1,14 +1,22 @@
 class PlaylistsController < ApplicationController
-  
+
+  before_action :playlist_set, only: [:show, :feed]
+
   def index
     @playlists = Playlist.all.order(created_at: :desc)
   end
-  
-  def show
-    @playlist = Playlist.friendly.find(params[:id])
-    if params[:id] != @playlist.slug
-      redirect_to @playlist, status: 301
-    end
+
+  def feed
+    @videos = @playlist.videos.reverse
+    @updated_at = Video.order(updated_at: :desc).limit(1).pluck(:updated_at).first
+    render format: :xml, template: 'playlists/feed.xml.erb', layout: false
   end
-  
+
+  private
+
+  def playlist_set
+    @playlist = Playlist.friendly.find(params[:id])
+    redirect_to @playlist, status: 301 if params[:id] != @playlist.slug
+  end
+
 end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -7,7 +7,7 @@ class PlaylistsController < ApplicationController
   end
 
   def feed
-    @videos = @playlist.videos.reverse
+    @videos = @playlist.videos.includes(:playlist, playlist: [:topic]).visible.reverse
     @updated_at = Video.order(updated_at: :desc).limit(1).pluck(:updated_at).first
     render format: :xml, template: 'playlists/feed.xml.erb', layout: false
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -7,7 +7,7 @@ class TopicsController < ApplicationController
   end
 
   def feed
-    @videos = Video.joins(:playlist).where(playlists: { topic: @topic }).order(published_at: :desc).limit(15)
+    @videos = Video.visible.joins(:playlist).includes(:playlist, playlist: [:topic]).where(playlists: { topic: @topic }).order(published_at: :desc).limit(15)
     @updated_at = Video.order(updated_at: :desc).limit(1).pluck(:updated_at).first
     render format: :xml, template: 'topics/feed.xml.erb', layout: false
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,11 +1,21 @@
 class TopicsController < ApplicationController
-  
+
+  before_action :topic_set, only: [:show, :feed]
+
   def index
     @topics = Topic.all
   end
 
-  def show
-    @topic = Topic.friendly.find(params[:id])
+  def feed
+    @videos = Video.joins(:playlist).where(playlists: { topic: @topic }).order(published_at: :desc).limit(15)
+    @updated_at = Video.order(updated_at: :desc).limit(1).pluck(:updated_at).first
+    render format: :xml, template: 'topics/feed.xml.erb', layout: false
   end
 
+  private
+
+  def topic_set
+    @topic = Topic.friendly.find(params[:id])
+    redirect_to topic_path(@topic) if params[:id] != @topic.slug
+  end
 end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -19,7 +19,7 @@ class VideosController < ApplicationController
   end
 
   def feed
-    @videos = Video.order(published_at: :desc).limit(15)
+    @videos = Video.visible.includes(:playlist, playlist: [:topic]).order(published_at: :desc).limit(15)
     @updated_at = Video.order(updated_at: :desc).limit(1).pluck(:updated_at).first
     render format: :xml, template: 'videos/feed.xml.erb', layout: false
   end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -17,4 +17,10 @@ class VideosController < ApplicationController
     authenticate_user! if @video.scheduled? && @video.private
     @in_playlist = @video.higher_items(5) + [@video] + @video.lower_items(5)
   end
+
+  def feed
+    @videos = Video.order(published_at: :desc).limit(15)
+    @updated_at = Video.order(updated_at: :desc).limit(1).pluck(:updated_at).first
+    render format: :xml, template: 'videos/feed.xml.erb', layout: false
+  end
 end

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -13,6 +13,8 @@
 <title><%= content_for?(:title) ? content_for(:title) : "makigas" %></title>
 <%= tag(:meta, name: 'description', content: content_for(:description)) if content_for?(:description) %>
 <%= tag(:link, rel: 'canonical', href: canonical_url) %>
+<%= tag(:link, rel: 'alternate', href: feed_videos_url, title: t('.videos_feed'), type: 'application/atom+xml') %>
+
 <%= content_for(:meta) if content_for?(:meta) -%>
 <%= content_for(:twitter) -%>
 <%= content_for(:facebook) -%>

--- a/app/views/playlists/feed.xml.erb
+++ b/app/views/playlists/feed.xml.erb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="es-ES">
+
+    <title type="text">makigas (<%= @playlist.title %>)</title>
+    <subtitle type="text">Lista de reproducción para el tema <%= @playlist.title %></subtitle>
+    <updated><%= @updated_at.iso8601 %></updated>
+
+    <id><%= feed_playlist_url(@playlist) %></id>
+    <icon><%= @playlist.thumbnail.url %></icon>
+    <logo><%= @playlist.thumbnail.url %></logo>
+    <link rel="self" href="<%= feed_playlist_url(@playlist) %>" type="application/atom+xml" />
+    <link rel="alternate" href="<%= playlist_url(@playlist) %>" type="text/html" />
+
+    <author><name>makigas.es</name></author>
+    <generator uri="https://github.com/makigas/makigas">makigas.es</generator>
+
+    <%- @videos.each do |video| -%>
+    <%= render 'videos/atom', video: video %>
+    <%- end -%>
+
+</feed>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -16,6 +16,11 @@
 <meta property="og:image" content="<%= image_url(@playlist.card.url, only_path: false) %>">
 <% end %>
 
+<% content_for :meta do %>
+<%= tag(:link, rel: :alternate, href: feed_playlist_url(@playlist), title: t('.meta.playlist_feed', playlist: @playlist.title), type: 'application/atom+xml') %>
+<%= tag(:link, rel: :alternate, href: feed_topic_url(@playlist.topic), title: t('.meta.topic_feed', topic: @playlist.topic.title), type: 'application/atom+xml') if @playlist.topic.present? %>
+<% end %>
+
 <% if @playlist.topic %>
 <% content_for :header do %>
 <style>

--- a/app/views/topics/feed.xml.erb
+++ b/app/views/topics/feed.xml.erb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="es-ES">
+
+    <title type="text">makigas (<%= @topic.title %>)</title>
+    <subtitle type="text">Vídeos recientes publicados en el tema <%= @topic.title %></subtitle>
+    <updated><%= @updated_at.iso8601 %></updated>
+
+    <id><%= feed_topic_url(@topic) %></id>
+    <icon><%= @topic.thumbnail.url %></icon>
+    <logo><%= @topic.thumbnail.url %></logo>
+    <link rel="self" href="<%= feed_topic_url(@topic) %>" type="application/atom+xml" />
+    <link rel="alternate" href="<%= topic_url(@topic) %>" type="text/html" />
+
+    <author><name>makigas.es</name></author>
+    <generator uri="https://github.com/makigas/makigas">makigas.es</generator>
+
+    <%- @videos.each do |video| -%>
+    <%= render 'videos/atom', video: video %>
+    <%- end -%>
+
+</feed>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -16,6 +16,10 @@
 <meta property="og:image" content="<%= image_url(@topic.thumbnail.url, only_path: false) %>">
 <% end %>
 
+<% content_for :meta do %>
+<%= tag(:link, rel: :alternate, href: feed_topic_url(@topic), title: t('.meta.topic_feed', topic: @topic.title), type: 'application/atom+xml') %>
+<% end %>
+
 <% content_for :header do %>
 <style>
 .main-header, .hero-tron { background: <%= @topic.color %>; }

--- a/app/views/videos/_atom.xml.erb
+++ b/app/views/videos/_atom.xml.erb
@@ -1,0 +1,12 @@
+<entry>
+    <id><%= video_url(video) %></id>
+    <updated><%= video.published_at.iso8601 %></updated>
+    <link rel="alternate" href="<%= video_url(video) %>" type="text/html" />
+
+    <title type="html"><![CDATA[<%= video.title %>]]></title>
+    <summary type="html"><![CDATA[<%= video.description %>]]></summary>
+    <category term="<%= video.playlist.title %>" />
+    <%- if video.playlist.topic.present? -%>
+    <category term="<%= video.playlist.topic.title %>" />
+    <%- end -%>
+</entry>

--- a/app/views/videos/feed.xml.erb
+++ b/app/views/videos/feed.xml.erb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="es-ES">
+
+    <title type="text">makigas</title>
+    <subtitle type="text">Vídeos recientes publicados en makigas</subtitle>
+    <updated><%= @updated_at.iso8601 %></updated>
+
+    <id><%= feed_videos_url %></id>
+    <icon><%= URI.join(root_url, 'makigas.png') %></icon>
+    <logo><%= URI.join(root_url, 'makigas.png') %></logo>
+    <link rel="self" href="<%= feed_videos_url %>" type="application/atom+xml" />
+    <link rel="alternate" href="<%= videos_url %>" type="text/html" />
+
+    <author><name>makigas.es</name></author>
+    <generator uri="https://github.com/makigas/makigas">makigas.es</generator>
+
+    <%- @videos.each do |video| -%>
+    <%= render 'videos/atom', video: video %>
+    <%- end -%>
+
+</feed>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -16,6 +16,8 @@
 <meta property="og:image" content="<%= image_url(@video.playlist.card.url, only_path: false) %>">
 <% end %>
 <% content_for :meta do %>
+  <%= tag(:link, rel: :alternate, href: feed_playlist_url(@playlist), title: t('.meta.playlist_feed', playlist: @playlist.title), type: 'application/atom+xml') %>
+  <%= tag(:link, rel: :alternate, href: feed_topic_url(@playlist.topic), title: t('.meta.topic_feed', topic: @playlist.topic.title), type: 'application/atom+xml') if @playlist.topic.present? %>
   <% if @video.scheduled? %>
   <meta name="robots" content="noindex">
   <% end %>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -65,6 +65,8 @@ es:
       message: "Me obligan a informarte que este sitio usa cookies."
       dismiss: "Me entero"
       learn_more: "Lee más sobre las cookies"
+    head:
+      videos_feed: Vídeos recientes (ATOM)
     header:
       navigation: Desplegar navegación
       playlists: Listas
@@ -108,6 +110,10 @@ es:
         one: 1 episodio
         other: "%{count} episodios"
       title: Todas las listas de reproducción
+    show:
+      meta:
+        playlist_feed: "Lista: %{playlist} (ATOM)"
+        topic_feed: "Tema: %{topic} (ATOM)"
   topics:
     index:
       meta:
@@ -117,6 +123,7 @@ es:
     show:
       meta:
         description: Explora las listas de reproducción que hay dentro de esta categoría o encuentra contenido adicional.
+        topic_feed: "Tema: %{topic} (ATOM)"
       episode:
         one: 1 episodio
         other: "%{count} episodios"
@@ -151,3 +158,6 @@ es:
         other: Una lista de reproducción de %{count} episodios.
       this_playlist: Lista de reproducción
       this_topic: Este tema
+      meta:
+        playlist_feed: "Lista: %{playlist} (ATOM)"
+        topic_feed: "Tema: %{topic} (ATOM)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,9 +24,17 @@ Rails.application.routes.draw do
 
   # Main application routes
   root to: 'front#index'
-  resources :topics, only: [:index, :show], constraints: { format: :html }
-  resources :videos, only: :index, constraints: { format: :html }
+
+  resources :topics, only: [:index, :show], constraints: { format: :html } do
+    get :feed, on: :member
+  end
+
+  resources :videos, only: :index, constraints: { format: :html } do
+    get :feed, on: :collection
+  end
+
   resources :playlists, path: 'series', only: [:index, :show], constraints: { format: :html } do
+    get :feed, on: :member
     resources :videos, path: '/', only: [:show], constraints: { format: :html }
   end
   get :terms, to: 'pages#terms'


### PR DESCRIPTION
This PR adds support for ATOM Feeds on the items in this site. This means that RSS/Atom clients could subscribe to updates on this site in order to get notified whenever new content is available on the site.

The following endpoints have been added:

* www.makigas.es/videos/feed: syndicates recent videos.
* www.makigas.es/topics/:topic/feed: syndicates recent videos in the topic :topic.
* www.makigas.es/serie/:playlist/feed: syndicates all the videos in the playlist :playlist.

Every endpoint must return a valid ATOM+XML document. This site does not do RSS, although most RSS clients will be able to subscribe to the ATOM feeds provided by this site.