### PR TITLE
Update Ruby to 2.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 branches:
   only:
     - master
-rvm: 2.4.1
+rvm:
+  - 2.4
+  - 2.5
 services:
   - postgresql
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ruby:2.4.1-alpine
 LABEL maintainer="dani@danirod.es"
 
 # Install dependencies.
-RUN apk add --update alpine-sdk postgresql-dev imagemagick nodejs tzdata && \
+RUN apk add --update build-base file postgresql-dev imagemagick nodejs tzdata && \
     npm install -g yarn
 
 # Initializes the working directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # develop or test the application in a standalone application
 # without having to install the stuff.
 
-FROM ruby:2.4.1-alpine
+FROM ruby:2.4-alpine3.7
 LABEL maintainer="dani@danirod.es"
 
 # Install dependencies.

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,6 +1,6 @@
 # The Dockerfile used for testing makigas.
 
-FROM ruby:2.4.4-alpine3.7
+FROM ruby:2.4-alpine3.7
 LABEL maintainer="dani@danirod.es"
 
 # Install runtime dependencies


### PR DESCRIPTION
Note that this only affects the Ruby version used by the Docker container, which is not deployed in production at the moment. (Although it eventually will.)

Also note that we've been testing using Ruby 2.4.4 for a long time using the spec Dockerfile, so we already know that makigas.es works on Ruby 2.4.4.

Travis-CI now will test against Ruby 2.4 and Ruby 2.5 to prepare for a possible upgrade, although we may just wait until Ruby 2.6 for that.