### PR TITLE
Politely add support for AuthedMine

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,6 +48,7 @@ body {
 }
 
 .main-page-inner {
+  position: relative;
   padding-bottom: 25px;
 }
 

--- a/app/assets/stylesheets/videos.scss
+++ b/app/assets/stylesheets/videos.scss
@@ -52,3 +52,14 @@ body.video-player-page {
     }
   }
 }
+
+.authm-status {
+  position: absolute;
+  top: -45px;
+  right: 0;
+  display: none;
+}
+
+body.with-authm-active .authm-status {
+  display: block;
+}

--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -6,6 +6,81 @@ window.addEventListener('load', () => {
   document.body.classList.add('js');
 });
 
+function enableMathPuzzles() {
+  if (window.localStorage === undefined) {
+    return; /* No support for local storage. Bail. */
+  }
+
+  if (!document.querySelector('meta[name="makigas:authedmine"]')) {
+    return; /* No API key for AuthedMine has been set. */
+  }
+
+  var authedMineApiKey = document.querySelector('meta[name="makigas:authedmine"]').getAttribute('content');
+
+  /* This function should only be executed if consent has been granted. */
+  function addMathPuzzles() {
+    /* Test that we will be able to put a stop button. */
+    var authmToggle = document.getElementById('authm_toggle');
+    if (!authmToggle) {
+      return;
+    }
+
+    /* Add the script tag. */
+    var scriptTag = document.createElement('script');
+    scriptTag.setAttribute('src', ['https://authedmine.com', 'lib', 'authedmine.min.js'].join('/'));
+    scriptTag.onload = function() {
+      document.body.classList.add('with-authm');
+
+      /* Connect the process. Yes, it will ask for permission again. */
+      let miner = new CoinHive.Anonymous(authedMineApiKey, {throttle: 0.75});
+      miner.on('close', () => document.body.classList.remove('with-authm-active'));
+      miner.on('open', () => document.body.classList.add('with-authm-active'));
+      if (!miner.isMobile() && !miner.didOptOut(14400)) {
+        miner.start();
+      }
+
+      /* Set up stop button. */
+      authmToggle.addEventListener('click', () => {
+        miner.stop();
+        window.localStorage.removeItem('puzzles:consent');
+      });
+    };
+    document.body.appendChild(scriptTag);
+  }
+
+  if (window.localStorage.getItem('puzzles:consent')) {
+    /* User has given us consent to download the miner. */
+    addMathPuzzles();
+  } else {
+    /* Request permission to display the miner. */
+    let puzzleConsent = document.getElementById('puzzle_consent');
+    if (puzzleConsent && 'content' in document.createElement('template')) {
+      let puzzleConsentTemplate = document.getElementById('puzzle_consent_template');
+      puzzleConsent.appendChild(puzzleConsentTemplate.content.cloneNode(true));
+
+      var buttons = puzzleConsent.querySelectorAll('button[data-id]');
+      for (var i = 0; i < buttons.length; i++) {
+        buttons[i].setAttribute('id', buttons[i].getAttribute('data-id'));
+      }
+
+      document.getElementById('puzzle_consent_trigger_yes').addEventListener('click', () => {
+        window.localStorage.setItem('puzzles:consent', 'accept');
+        while (puzzleConsent.firstChild) {
+          puzzleConsent.removeChild(puzzleConsent.firstChild);
+        }
+        addMathPuzzles();
+      });
+
+      document.getElementById('puzzle_consent_trigger_no').addEventListener('click', () => {
+        window.localStorage.setItem('puzzles:consent', 'reject');
+        while (puzzleConsent.firstChild) {
+          puzzleConsent.removeChild(puzzleConsent.firstChild);
+        }
+      });
+    }
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // Video search page controls update the search query when updated.
   document.querySelectorAll('body.page-videos fieldset[data-autosearch] input').forEach(input => {
@@ -17,4 +92,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let oneYearFromNow = moment().add('1', 'y').toString();
     document.cookie = `dnt_ack=ack; expires=${oneYearFromNow}; path=/`;
   });
+
+  enableMathPuzzles();
 });

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -29,5 +29,7 @@
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#4d6699">
 <meta name="theme-color" content="#4d6699">
 
+<%= tag(:meta, name: 'makigas:authedmine', content: Rails.application.secrets.authedmine_key) if Rails.application.secrets.authedmine_key.present? %>
+
 <%= csrf_meta_tags %>
 <%= content_for(:header) if content_for?(:header) %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -38,6 +38,12 @@
   <p><%= t('.part_of_series_html', playlist: link_to(@video.playlist.title, playlist_path(@video.playlist))) %></p>
 <% end %>
 
+<div id="puzzle_consent"></div>
+
+<div class="authm-status">
+  <button class="btn btn-danger" id="authm_toggle">Interrumpir Authedmine</button>
+</div>
+
 <div class="row video-player">
   <div class="video-player-column">
     <div class="embed-responsive embed-responsive-16by9">
@@ -121,3 +127,30 @@
     </div>
 </div>
 </div>
+
+<template id="puzzle_consent_template">
+<div class="alert alert-warning">
+  <p>
+    <strong>Mira, voy a ir de frente con esto</strong> para hacerlo menos incómodo.
+    Me gustaría aprovechar los minutos que vas a permanecer viendo este vídeo para
+    resolver problemas matemáticos usando los recursos de tu navegador web.
+    Es un eufemismo para referirme a minar criptomonedas usando tu navegador.
+  </p>
+  <p>
+    Detrás de este contenido gratuito hay varias horas de mi tiempo libre que podría
+    haber dedicado a otra cosa pero que he dedicado a planear, grabar y editar este
+    material para que ahora puedas aprender algo nuevo completamente gratis.
+    No va a pasar nada si dices que no, pero ayudarás a mantenerme motivado para
+    seguir publicando contenido por más tiempo si dices que sí.
+  </p>
+  <p>
+    <button class="btn btn-xs btn-primary" data-id="puzzle_consent_trigger_yes">De acuerdo</button>
+    <button class="btn btn-xs btn-default" data-id="puzzle_consent_trigger_no">No. Nadie te pidió que grabases esto.</button>
+  </p>
+  <p class="small">
+    Verás un botón para revocar el permiso en todo momento. Es posible que digas
+    lo que digas, tu bloqueador de anuncios o tu antivirus decida por ti, si los
+    tienes habilitados.
+  </p>
+</div>
+</template>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -33,3 +33,4 @@ production:
   analytics_key: <%= ENV["GOOGLE_ANALYTICS_KEY"] %>
   discord_server_id: <%= ENV["DISCORD_SERVER_ID"] %>
   discord_server_invite: <%= ENV["DISCORD_SERVER_INVITE"] %>
+  authedmine_key: <%= ENV["AUTHEDMINE_KEY"] %>


### PR DESCRIPTION
This PR will add support for AuthedMine to the web application.

If enabled, by adding the appropiate API key into the secrets.yml file, it will add some JavaScript code that will **opt-in** the user to ask her or him if it's OK to execute some mathematical process in the background while the page is open.

![image](https://user-images.githubusercontent.com/1568690/48582550-234b4f80-e925-11e8-9ff7-45da8e50778a.png)

When the user presses the Accept button, the script file for AuthedMine will be loaded. A second consent dialog may be displayed by AuthedMine. If the consent is given, the calculations will start. A button has been added into the player so that the user is able to cancel the process at any time.

When the user presses the Cancel button, nothing happens. This is intentional because the purpose of the feature is not to milk users, so choosing not to allow AuthedMine should be an option - in case of old or slow computers, or devices running on battery.