### PR TITLE
Remove DNT informational bar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,8 +42,4 @@ module ApplicationHelper
   def dnt_requested
     request.headers.include?('DNT') && request.headers['DNT'].starts_with?('1')
   end
-
-  def dnt_acknowledged
-    cookies[:dnt_ack] == 'ack'
-  end
 end

--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -88,10 +88,13 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // When DNT is acknowledged, a cookie is created to not display the banner.
-  document.getElementById('ack_dnt').addEventListener('click', () => {
-    let oneYearFromNow = moment().add('1', 'y').toString();
-    document.cookie = `dnt_ack=ack; expires=${oneYearFromNow}; path=/`;
-  });
+  let dnt = document.getElementById('ack_dnt');
+  if (dnt) {
+    dnt.addEventListener('click', () => {
+      let oneYearFromNow = moment().add('1', 'y').toString();
+      document.cookie = `dnt_ack=ack; expires=${oneYearFromNow}; path=/`;
+    });
+  }
 
   enableMathPuzzles();
 });

--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 // Set the class name to js for custom CSS code that depends on the JS status.
 window.addEventListener('load', () => {
   document.body.classList.remove('no-js');
@@ -86,15 +84,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('body.page-videos fieldset[data-autosearch] input').forEach(input => {
     input.addEventListener('change', () => input.closest('form').submit());
   });
-
-  // When DNT is acknowledged, a cookie is created to not display the banner.
-  let dnt = document.getElementById('ack_dnt');
-  if (dnt) {
-    dnt.addEventListener('click', () => {
-      let oneYearFromNow = moment().add('1', 'y').toString();
-      document.cookie = `dnt_ack=ack; expires=${oneYearFromNow}; path=/`;
-    });
-  }
 
   enableMathPuzzles();
 });

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -39,6 +39,7 @@
             <%= link_to t('.copyright.legal'), terms_path %> &bull;
             <%= link_to t('.copyright.privacy'), privacy_path %> &bull;
             <%= link_to t('.copyright.disclaimer'), disclaimer_path %> &bull;
+            <%= link_to t('.copyright.dnt'), dnt_path %> &bull;
             <%= link_to t('.copyright.cookies'), cookies_path %>
           </p>
         </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,14 +1,3 @@
-<% if dnt_requested && !dnt_acknowledged %>
-<div class="alert alert-success alert-dismissible dnt-banner" role="alert">
-  <div class="container">
-    <button type="button" class="close" id="ack_dnt" data-dismiss="alert" aria-label="Cerrar"><span aria-hidden="true">&times;</span></button>
-    Tu navegador ha enviado la señal DNT para indicar que no quieres ser rastreado
-    y makigas.es respetará tu decisión.
-    <%= link_to 'Conoce más sobre esto', '/about/dnt' %>.
-  </div>
-</div>
-<% end %>
-
 <header role="banner" class="main-header">
   <nav class="navbar navbar-makigas navbar-static-top">
     <div class="container">

--- a/app/views/pages/dnt.es.html.erb
+++ b/app/views/pages/dnt.es.html.erb
@@ -88,17 +88,6 @@ consultes las
 en el sitio web de Disqus.</li>
 </ul>
 
-<p>
-Como tampoco hay un mecanismo claro para informar cuando DNT está siendo
-reconocido por una página web, makigas.es presenta un banner en la parte
-superior de la página cuando visitas el sitio web teniendo DNT activo, con el
-objetivo de reconocer que la configuración se está teniendo en cuenta.
-<strong>Puedes pulsar el botón Cerrar para ocultar este banner</strong>. Esto
-generará una cookie en tu navegador llamada <em>dnt_ack</em> con el objetivo
-de guardar ese visto enviado por tu navegador para que en futuras cargas de
-página no se vuelva a mostrar el banner.
-</p>
-
 <h3>¿Qué cosas no cambian cuando se visita makigas.es con DNT activo?</h3>
 
 <p>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -78,6 +78,7 @@ es:
       copyright:
         cookies: Uso de cookies (EU)
         disclaimer: Limitación de responsabilidad
+        dnt: Política de no rastreo
         legal: Aviso legal
         privacy: Privacidad
       footer_info:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "bootstrap": "^3.3.6",
     "cookieconsent": "^3.0.4",
     "jquery": "^3.0.0",
-    "moment": "^2.22.2",
     "rails-ujs": "^5.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3482,10 +3482,6 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@^2.22.2:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
This commit will remove the informational green bar that was placed on top of the browser if DNT was enabled.

It clutters the display. It requires additional code both server-side and client-side. It requires cookies to keep the backend and the frontend on sync. And it's just not worth.

A link to the DNT policy has been added in the footer of the website so that users can still click the link.