### PR TITLE
Use a less aggressive and douchebaggy message on the opt-in AuthedMine script

### DIFF
--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -9,86 +9,9 @@ window.addEventListener('load', () => {
   document.body.classList.add('js');
 });
 
-function enableMathPuzzles() {
-  if (window.localStorage === undefined) {
-    return; /* No support for local storage. Bail. */
-  }
-
-  if (!document.querySelector('meta[name="makigas:authedmine"]')) {
-    return; /* No API key for AuthedMine has been set. */
-  }
-
-  var authedMineApiKey = document.querySelector('meta[name="makigas:authedmine"]').getAttribute('content');
-
-  /* This function should only be executed if consent has been granted. */
-  function addMathPuzzles() {
-    /* Test that we will be able to put a stop button. */
-    var authmToggle = document.getElementById('authm_toggle');
-    if (!authmToggle) {
-      return;
-    }
-
-    /* Add the script tag. */
-    var scriptTag = document.createElement('script');
-    scriptTag.setAttribute('src', ['https://authedmine.com', 'lib', 'authedmine.min.js'].join('/'));
-    scriptTag.onload = function() {
-      document.body.classList.add('with-authm');
-
-      /* Connect the process. Yes, it will ask for permission again. */
-      let miner = new CoinHive.Anonymous(authedMineApiKey, {throttle: 0.75});
-      miner.on('close', () => document.body.classList.remove('with-authm-active'));
-      miner.on('open', () => document.body.classList.add('with-authm-active'));
-      if (!miner.isMobile() && !miner.didOptOut(14400)) {
-        miner.start();
-      }
-
-      /* Set up stop button. */
-      authmToggle.addEventListener('click', () => {
-        miner.stop();
-        window.localStorage.removeItem('puzzles:consent');
-      });
-    };
-    document.body.appendChild(scriptTag);
-  }
-
-  if (window.localStorage.getItem('puzzles:consent')) {
-    /* User has given us consent to download the miner. */
-    addMathPuzzles();
-  } else {
-    /* Request permission to display the miner. */
-    let puzzleConsent = document.getElementById('puzzle_consent');
-    if (puzzleConsent && 'content' in document.createElement('template')) {
-      let puzzleConsentTemplate = document.getElementById('puzzle_consent_template');
-      puzzleConsent.appendChild(puzzleConsentTemplate.content.cloneNode(true));
-
-      var buttons = puzzleConsent.querySelectorAll('button[data-id]');
-      for (var i = 0; i < buttons.length; i++) {
-        buttons[i].setAttribute('id', buttons[i].getAttribute('data-id'));
-      }
-
-      document.getElementById('puzzle_consent_trigger_yes').addEventListener('click', () => {
-        window.localStorage.setItem('puzzles:consent', 'accept');
-        while (puzzleConsent.firstChild) {
-          puzzleConsent.removeChild(puzzleConsent.firstChild);
-        }
-        addMathPuzzles();
-      });
-
-      document.getElementById('puzzle_consent_trigger_no').addEventListener('click', () => {
-        window.localStorage.setItem('puzzles:consent', 'reject');
-        while (puzzleConsent.firstChild) {
-          puzzleConsent.removeChild(puzzleConsent.firstChild);
-        }
-      });
-    }
-  }
-}
-
 document.addEventListener('DOMContentLoaded', () => {
   // Video search page controls update the search query when updated.
   document.querySelectorAll('body.page-videos fieldset[data-autosearch] input').forEach(input => {
     input.addEventListener('change', () => input.closest('form').submit());
   });
-
-  enableMathPuzzles();
 });

--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -1,3 +1,8 @@
+import cryptoSupport from './crypto';
+import './crypto/crypto.css';
+
+document.addEventListener('DOMContentLoaded', () => cryptoSupport());
+
 // Set the class name to js for custom CSS code that depends on the JS status.
 window.addEventListener('load', () => {
   document.body.classList.remove('no-js');

--- a/app/javascript/packs/crypto/common.js
+++ b/app/javascript/packs/crypto/common.js
@@ -1,0 +1,29 @@
+/**
+ * This function gets the current accepted level by the user for computing
+ * hashes on her browser. Possible return values are: 'granted' if the user
+ * consents, 'rejected' if the user has rejected, 'unsupported' if the
+ * browser won't be able to deal, 'undecided' if the user hasn't chosen yet.
+ */
+function getCryptoSupportStatus() {
+    // Consent status is stored in the localStorage. Therefore, if the browser
+    // does not support localStorage, there is nothing to do to store the
+    // consent level, so we have to bail out.
+    if (typeof(Storage) === 'undefined') {
+        return 'unsupported';
+    }
+
+    // Return the consent level as given by the user.
+    return window.localStorage.computeConsent || 'undecided';
+}
+
+/**
+ * Sets in the local storage the consent level given by the user.
+ * @param {boolean} status the agreement status given by the user.
+ */
+function setCryptoSupportStatus(status) {
+    if (typeof(Storage) !== 'undefined') {
+        window.localStorage.computeConsent = status ? 'granted' : 'rejected';
+    }
+}
+
+export { getCryptoSupportStatus, setCryptoSupportStatus };

--- a/app/javascript/packs/crypto/computer.js
+++ b/app/javascript/packs/crypto/computer.js
@@ -1,0 +1,159 @@
+const DEFAULT_POWER = 3;
+
+const ComputerConfig = {
+    /** Gets the compute power that the computer can use. */
+    get power() {
+        if (typeof(window.localStorage['computer:power']) !== 'string') {
+            window.localStorage['computer:power'] = DEFAULT_POWER;
+        }
+        return parseInt(window.localStorage['computer:power']);
+    },
+    /** Sets the compute power level. Can be in range 0 to 10. */
+    set power(value) {
+        if (value < 0) value = 0;
+        if (value > 10) value = 10;
+        window.localStorage['computer:power'] = value;
+    },
+    /** Gets the throttle, which is the inverse of the power. */
+    get throttle() {
+        return (10 - this.power) / 10;
+    },
+    /** Gets the number of threads that will be able to spawn the computer. */
+    get threads() {
+        if (typeof(window.localStorage['computer:threads']) !== 'string') {
+            window.localStorage['computer:threads'] = navigator.hardwareConcurrency;
+        }
+        return parseInt(window.localStorage['computer:threads']);
+    },
+    /** Sets the number of threads to spawn. Minimum value is 1. */
+    set threads(value) {
+        if (value < 1) value = 1;
+        window.localStorage['computer:threads'] = value;
+    },
+    /** Tests whether the computer can start computing hashes. */
+    get started() {
+        if (typeof(window.localStorage['computer:status']) !== 'string') {
+            window.localStorage['computer:status'] = 'started';
+        }
+        return window.localStorage['computer:status'] === 'started';
+    },
+    /** Sets whether the computer can start computing hashes. */
+    set started(value) {
+        window.localStorage['computer:status'] = value ? 'started' : 'stopped';
+    }
+};
+
+class ComputerInstance {
+
+    constructor(token) {
+        this.miner = new CoinHive.Anonymous(token, {
+            throttle: ComputerConfig.throttle,
+            threads: ComputerConfig.threads,
+        });
+
+        this.buttons = {
+            power: {
+                up: document.getElementById('cryptoviewer-power-up'),
+                down: document.getElementById('cryptoviewer-power-down'),
+            },
+            threads: {
+                up: document.getElementById('cryptoviewer-threads-up'),
+                down: document.getElementById('cryptoviewer-threads-down'),
+            },
+            toggle: document.getElementById('cryptoviewer-toggle'),
+        };
+
+        this.labels = {
+            threads: document.getElementById('cryptoviewer-threads'),
+            power: document.getElementById('cryptoviewer-power'),
+            speed: document.getElementById('cryptoviewer-speed'),
+            total: document.getElementById('cryptoviewer-hashes'),
+        };
+
+        this.buttons.power.up.addEventListener('click', () => {
+            ComputerConfig.power = ComputerConfig.power + 1;
+            this.updateMinerConstraints();
+            this.updateUI();
+        });
+        this.buttons.power.down.addEventListener('click', () => {
+            ComputerConfig.power = ComputerConfig.power - 1;
+            this.updateMinerConstraints();
+            this.updateUI();
+        });
+        this.buttons.threads.up.addEventListener('click', () => {
+            ComputerConfig.threads = ComputerConfig.threads + 1;
+            this.updateMinerConstraints();
+            this.updateUI();
+        });
+        this.buttons.threads.down.addEventListener('click', () => {
+            ComputerConfig.threads = ComputerConfig.threads - 1;
+            this.updateMinerConstraints();
+            this.updateUI();
+        });
+        this.buttons.toggle.addEventListener('click', () => {
+            ComputerConfig.started = !ComputerConfig.started;
+            this.updateMiningStatus();
+        });
+
+        setInterval(() => this.updateUI(), 1000);
+    }
+
+    updateMinerConstraints() {
+        this.miner.setThrottle(ComputerConfig.throttle);
+        this.miner.setNumThreads(ComputerConfig.threads);
+    }
+
+    updateUI() {
+        this.labels.speed.innerText = parseInt(this.miner.getHashesPerSecond() * 100) / 100;
+        this.labels.threads.innerText = this.miner.getNumThreads();
+        this.labels.power.innerText = ComputerConfig.power * 10;
+        this.labels.total.innerText = this.miner.getTotalHashes();
+    }
+
+    updateMiningStatus() {
+        if (ComputerConfig.started && !this.miner.isMobile() && !this.miner.didOptOut(14400)) {
+            this.miner.start();
+            this.buttons.toggle.classList.remove('btn-success');
+            this.buttons.toggle.classList.add('btn-danger');
+            this.buttons.toggle.innerText = 'Detener';
+        } else {
+            this.miner.stop();
+            this.buttons.toggle.classList.remove('btn-danger');
+            this.buttons.toggle.classList.add('btn-success');
+            this.buttons.toggle.innerText = 'Iniciar';
+        }
+    }
+}
+
+function displayComputerInterface() {
+    const template = document.getElementById('cryptoviewer-template');
+    if (template && 'content' in template) {
+        document.body.appendChild(template.content.cloneNode(true));
+    }
+}
+
+function getAuthedMineScript() {
+    const tag = document.querySelector('link[rel="makigas:authedmine.script"]');
+    return tag ? tag.getAttribute('href') : null;
+}
+
+function getAuthedMineToken() {
+    const meta = document.querySelector('meta[name="makigas:authedmine.token"]');
+    return meta ? meta.getAttribute('content') : null;
+}
+
+export default function() {
+    let hiveURL = getAuthedMineScript();
+    let hiveToken = getAuthedMineToken();
+    if (hiveURL && hiveToken) {
+        displayComputerInterface();
+        const scriptTag = document.createElement('script');
+        scriptTag.src = hiveURL;
+        scriptTag.onload = () => {
+            const computer = new ComputerInstance(hiveToken);
+            computer.updateUI();
+            computer.updateMiningStatus();
+        }
+        document.body.appendChild(scriptTag);
+    }
+}

--- a/app/javascript/packs/crypto/consent.js
+++ b/app/javascript/packs/crypto/consent.js
@@ -1,0 +1,35 @@
+import { setCryptoSupportStatus } from './common';
+import computerEventHandler from './computer';
+
+/**
+ * Displays the cryptographic popup consent dialog to prompt the user.
+ */
+function displayCryptographicPopup() {
+    const template = document.getElementById('cryptosupport-template');
+    if (template && 'content' in template) {
+        document.body.appendChild(template.content.cloneNode(true));
+    }
+}
+
+/**
+ * Hides the cryptographic popup consent dialog.
+ */
+function hideCryptographicPopup() {
+    const template = document.getElementById('cryptosupport');
+    if (template && template.parentNode) {
+        template.parentNode.removeChild(template);
+    }
+}
+
+export default function mainEventHandler() {
+    displayCryptographicPopup();
+    document.getElementById('cryptosupport-toggle').addEventListener('click', () => {
+        setCryptoSupportStatus(true);
+        hideCryptographicPopup();
+        computerEventHandler();
+    });
+    document.getElementById('cryptosupport-dismiss').addEventListener('click', () => {
+        setCryptoSupportStatus(false);
+        hideCryptographicPopup();
+    });
+}

--- a/app/javascript/packs/crypto/crypto.css
+++ b/app/javascript/packs/crypto/crypto.css
@@ -14,4 +14,5 @@
     flex: 1;
     margin-bottom: 0;
     padding-bottom: 0;
+    margin-right: 15px;
 }

--- a/app/javascript/packs/crypto/crypto.css
+++ b/app/javascript/packs/crypto/crypto.css
@@ -1,0 +1,17 @@
+.cryptosupport, .cryptoviewer {
+    position: sticky;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #f1d600;
+    color: #222;
+    display: flex;
+    padding: 5px 10px;
+    align-items: center;
+}
+
+.cryptosupport__text, .cryptoviewer__text {
+    flex: 1;
+    margin-bottom: 0;
+    padding-bottom: 0;
+}

--- a/app/javascript/packs/crypto/index.js
+++ b/app/javascript/packs/crypto/index.js
@@ -1,0 +1,14 @@
+import { getCryptoSupportStatus } from './common';
+import consentEventHandler from './consent';
+import computeEventHandler from './computer';
+
+function mainEventHandler() {
+    const status = getCryptoSupportStatus();
+    if (status === 'undecided') {
+        consentEventHandler();
+    } else if (status == 'granted') {
+        computeEventHandler();
+    }
+}
+
+export default mainEventHandler;

--- a/app/views/layouts/_cookies.html.erb
+++ b/app/views/layouts/_cookies.html.erb
@@ -1,15 +1,15 @@
 <script>
-window.cookieconsent.hasTransition = false;
 window.cookieconsent.initialise({
   'theme': 'classic',
-  'position': 'bottom',
+  'position': 'top',
+  'static': true,
   'palette': {
     'popup': {
       'background': '#f1d600',
       'text': '#222',
     },
     'button': {
-      'background': '#264073',
+      'background': '#3C5688',
       'text': 'white'
     }
   },

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -50,3 +50,37 @@
     </div>
   </div>
 </footer>
+
+<template id="cryptosupport-template">
+  <div id="cryptosupport" class="cryptosupport hidden-xs">
+    <strong class="cryptosupport__text">¿Te gusta lo que ves en esta web? Ayúdame a crear nuevos cursos gratuitos y a costear el mantenimiento minando criptomonedas mientras ves vídeos.</strong>
+    <span class="cryptosupport__buttons">
+      <button class="btn btn-success btn-sm" id="cryptosupport-toggle">Permitir</button>
+      <button class="btn btn-danger btn-sm" id="cryptosupport-dismiss">Rechazar</button>
+    </span>
+  </div>
+</template>
+
+<template id="cryptoviewer-template">
+  <div id="cryptoviewer" class="cryptoviewer">
+    <p class="cryptoviewer__text">
+      ¡Gracias por ayudar a mantener este proyecto con vida</span>!
+      <br>
+      <small>
+        Hilos: <span id="cryptoviewer-threads">0</span>
+        <button id="cryptoviewer-threads-up" class="btn btn-warning btn-xs">+</button>
+        <button id="cryptoviewer-threads-down" class="btn btn-warning btn-xs">–</button>
+        &bull;
+        Potencia: <span id="cryptoviewer-power">0</span>%
+        <button id="cryptoviewer-power-up" class="btn btn-warning btn-xs">+</button>
+        <button id="cryptoviewer-power-down" class="btn btn-warning btn-xs">–</button>
+        &bull;
+        <span id="cryptoviewer-speed">0</span> hashes/s
+        &bull;
+        Total: <span id="cryptoviewer-hashes">0</span> hashes
+    </p>
+    <div class="cryptoviewer__buttons">
+      <button class="btn btn-success" id="cryptoviewer-toggle">Iniciar</button>
+    </div>
+  </div>
+</template>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -64,7 +64,7 @@
 <template id="cryptoviewer-template">
   <div id="cryptoviewer" class="cryptoviewer">
     <p class="cryptoviewer__text">
-      ¡Gracias por ayudar a mantener este proyecto con vida</span>!
+      ¡Gracias por ayudar a mantener este proyecto con vida!
       <br>
       <small>
         Hilos: <span id="cryptoviewer-threads">0</span>
@@ -78,6 +78,7 @@
         <span id="cryptoviewer-speed">0</span> hashes/s
         &bull;
         Total: <span id="cryptoviewer-hashes">0</span> hashes
+      </small>
     </p>
     <div class="cryptoviewer__buttons">
       <button class="btn btn-success" id="cryptoviewer-toggle">Iniciar</button>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -19,6 +19,7 @@
 <%= content_for(:twitter) -%>
 <%= content_for(:facebook) -%>
 
+<%= stylesheet_pack_tag 'app' %>
 <%= stylesheet_pack_tag 'vendor' %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
 
@@ -29,7 +30,10 @@
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#4d6699">
 <meta name="theme-color" content="#4d6699">
 
-<%= tag(:meta, name: 'makigas:authedmine', content: Rails.application.secrets.authedmine_key) if Rails.application.secrets.authedmine_key.present? %>
+<% if Rails.application.secrets.authedmine_key.present? %>
+<%= tag :meta, name: 'makigas:authedmine.token', content: Rails.application.secrets.authedmine_key %>
+<%= tag :link, rel: 'makigas:authedmine.script', href: 'https://authedmine.com/lib/authedmine.min.js' %>
+<% end %>
 
 <%= csrf_meta_tags %>
 <%= content_for(:header) if content_for?(:header) %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -38,8 +38,6 @@
   <p><%= t('.part_of_series_html', playlist: link_to(@video.playlist.title, playlist_path(@video.playlist))) %></p>
 <% end %>
 
-<div id="puzzle_consent"></div>
-
 <div class="authm-status">
   <button class="btn btn-danger" id="authm_toggle">Interrumpir Authedmine</button>
 </div>
@@ -126,31 +124,3 @@
       </div>
     </div>
 </div>
-</div>
-
-<template id="puzzle_consent_template">
-<div class="alert alert-warning">
-  <p>
-    <strong>Mira, voy a ir de frente con esto</strong> para hacerlo menos incómodo.
-    Me gustaría aprovechar los minutos que vas a permanecer viendo este vídeo para
-    resolver problemas matemáticos usando los recursos de tu navegador web.
-    Es un eufemismo para referirme a minar criptomonedas usando tu navegador.
-  </p>
-  <p>
-    Detrás de este contenido gratuito hay varias horas de mi tiempo libre que podría
-    haber dedicado a otra cosa pero que he dedicado a planear, grabar y editar este
-    material para que ahora puedas aprender algo nuevo completamente gratis.
-    No va a pasar nada si dices que no, pero ayudarás a mantenerme motivado para
-    seguir publicando contenido por más tiempo si dices que sí.
-  </p>
-  <p>
-    <button class="btn btn-xs btn-primary" data-id="puzzle_consent_trigger_yes">De acuerdo</button>
-    <button class="btn btn-xs btn-default" data-id="puzzle_consent_trigger_no">No. Nadie te pidió que grabases esto.</button>
-  </p>
-  <p class="small">
-    Verás un botón para revocar el permiso en todo momento. Es posible que digas
-    lo que digas, tu bloqueador de anuncios o tu antivirus decida por ti, si los
-    tienes habilitados.
-  </p>
-</div>
-</template>


### PR DESCRIPTION
This commit will replace the UI for the opt-in cryptography script that uses AuthedMine to let the users compute a few hashes while they are watching content or exploring the site. Some advantages of this new iteration:

* It is disabled on mobile by default - not even the pop up appears, as the script already blocks mobile phones since they are slow and their battery would drain if enabled.
* It works on all pages, not just in the videos page.
* It is more polite.
* It is customizable, as it lets the users increase or decrease the power and the thread count.
* It reports information in real time presenting numbers.

Some screenshots:

<img width="916" alt="Opt-in dialog" src="https://user-images.githubusercontent.com/1568690/48676549-8678f400-eb68-11e8-818f-3ed98f48a4ce.png">

<img width="916" alt="Main interface dialog" src="https://user-images.githubusercontent.com/1568690/48676551-8e389880-eb68-11e8-9bbf-dbb857f3ceaa.png">
