### PR TITLE
fix: fix Capybara deprecation notice

### DIFF
--- a/spec/features/dashboard/playlist_videos_spec.rb
+++ b/spec/features/dashboard/playlist_videos_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
     scenario "user can access this page via video count link" do
       visit dashboard_playlists_path
       within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do
-        click_link @playlist.videos.count
+        click_link "#{@playlist.videos.count}"
       end
       expect(page.current_path).to eq videos_dashboard_playlist_path(@playlist)
     end

--- a/spec/features/dashboard/playlist_videos_spec.rb
+++ b/spec/features/dashboard/playlist_videos_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
     scenario "user can access this page via video count link" do
       visit dashboard_playlists_path
       within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do
-        click_link "#{@playlist.videos.count}"
+        click_link @playlist.videos.count.to_s
       end
       expect(page.current_path).to eq videos_dashboard_playlist_path(@playlist)
     end


### PR DESCRIPTION
I am seeing the following in the logs:

```
Locator Integer:2 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara.
```

Which is caused because of a number being passed to a selector. This PR should fix ocurrences so that Capybara stop complaining about it.