### PR TITLE
fix: ignore dependency directories in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,9 @@ require:
   - rubocop-rails
   - rubocop-rspec
 
+AllCops:
+  TargetRubyVersion: 2.6
+  Exclude:
+    - 'node_modules/**/*'
+
 inherit_from: .rubocop_todo.yml


### PR DESCRIPTION
There are Ruby files inside node_modules that are being catched by rubocop, causing errors that I cannot solve. This PR forces rubocop to ignore such directories.