### PR TITLE
lint: address Capybara/CurrentPathExpectation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,19 +14,6 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
-# Offense count: 10
-# Cop supports --auto-correct.
-Capybara/CurrentPathExpectation:
-  Exclude:
-    - 'spec/features/dashboard/dashboard_spec.rb'
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
-    - 'spec/features/front/front_page_spec.rb'
-    - 'spec/features/videos/video_page_spec.rb'
-
 # Offense count: 93
 # Cop supports --auto-correct.
 # Configuration parameters: EnabledMethods.

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Dashboard", type: :feature do
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_path
-      expect(page.current_path).not_to eq dashboard_topics_path
+      expect(page).to have_no_current_path dashboard_topics_path
     end
   end
 

--- a/spec/features/dashboard/opinions_spec.rb
+++ b/spec/features/dashboard/opinions_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Dashboard opinions", type: :feature do
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_opinions_path
-      expect(page.current_path).not_to eq dashboard_topics_path
+      expect(page).to have_no_current_path dashboard_topics_path
     end
   end
 

--- a/spec/features/dashboard/playlist_videos_spec.rb
+++ b/spec/features/dashboard/playlist_videos_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
   context "when not logged in" do
     it "should not be success" do
       visit videos_dashboard_playlist_path(@playlist)
-      expect(page.current_path).not_to eq videos_dashboard_playlist_path(@playlist)
+      expect(page).to have_no_current_path videos_dashboard_playlist_path(@playlist)
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
       within(".dashboard-page") do
         click_link "Vídeos"
       end
-      expect(page.current_path).to eq videos_dashboard_playlist_path(@playlist)
+      expect(page).to have_current_path videos_dashboard_playlist_path(@playlist)
     end
 
     scenario "user can access this page via video count link" do
@@ -39,7 +39,7 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
       within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do
         click_link @playlist.videos.count.to_s
       end
-      expect(page.current_path).to eq videos_dashboard_playlist_path(@playlist)
+      expect(page).to have_current_path videos_dashboard_playlist_path(@playlist)
     end
 
     scenario "this page lists videos in the right order" do

--- a/spec/features/dashboard/playlists_spec.rb
+++ b/spec/features/dashboard/playlists_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Dashboard playlists", type: :feature do
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_playlists_path
-      expect(page.current_path).not_to eq dashboard_playlists_path
+      expect(page).to have_no_current_path dashboard_playlists_path
     end
   end
 

--- a/spec/features/dashboard/topics_spec.rb
+++ b/spec/features/dashboard/topics_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Dashboard topics", type: :feature do
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_topics_path
-      expect(page.current_path).not_to eq dashboard_topics_path
+      expect(page).to have_no_current_path dashboard_topics_path
     end
   end
 

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
   context "when not logged in" do
     it "should not be success" do
       visit dashboard_videos_path
-      expect(page.current_path).not_to eq dashboard_playlists_path
+      expect(page).to have_no_current_path dashboard_playlists_path
     end
   end
 

--- a/spec/features/front/front_page_spec.rb
+++ b/spec/features/front/front_page_spec.rb
@@ -14,6 +14,6 @@ RSpec.feature "Front page", type: :feature do
   scenario "allows the user to navigate for topics" do
     visit root_path
     click_link 'Explora las temáticas'
-    expect(current_path).to eq topics_path
+    expect(page).to have_current_path topics_path
   end
 end

--- a/spec/features/videos/video_page_spec.rb
+++ b/spec/features/videos/video_page_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Video page", type: :feature do
 
     scenario 'the page requires authorization' do
       visit_video @video
-      expect(current_path).not_to eq playlist_video_path(@video, playlist_id: @video.playlist)
+      expect(page).to have_no_current_path playlist_video_path(@video, playlist_id: @video.playlist)
     end
 
     context 'user is logged in' do


### PR DESCRIPTION
This commit fix offenses for Capybara/CurrentPathExpectation.