### PR TITLE
chore: correct Style/* cops in rubocop_todo.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,10 @@ AllCops:
     - 'tmp/**/*'
 
 inherit_from: .rubocop_todo.yml
+
+# Rails actually suggests using this approach when setting redirect rules.
+# https://guides.rubyonrails.org/routing.html#redirection. Therefore, I'll
+# be ignoring config/routes.rb.
+Style/FormatStringToken:
+  Exclude:
+    - config/routes.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ AllCops:
 
 inherit_from: .rubocop_todo.yml
 
+Style/Documentation:
+  Enabled: false
+
 # Rails actually suggests using this approach when setting redirect rules.
 # https://guides.rubyonrails.org/routing.html#redirection. Therefore, I'll
 # be ignoring config/routes.rb.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,10 @@ require:
 AllCops:
   TargetRubyVersion: 2.6
   Exclude:
+    - 'bin/*'
+    - 'db/schema.rb'
     - 'node_modules/**/*'
+    - 'lib/tasks/**/*'
+    - 'tmp/**/*'
 
 inherit_from: .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -654,13 +654,6 @@ Style/StderrPuts:
   Exclude:
     - 'bin/yarn'
 
-# Offense count: 429
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -625,12 +625,6 @@ Style/PercentLiteralDelimiters:
     - 'config/initializers/assets.rb'
     - 'config/spring.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/RedundantBegin:
-  Exclude:
-    - 'bin/yarn'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -648,12 +648,6 @@ Style/RegexpLiteral:
     - 'app/models/playlist.rb'
     - 'app/models/topic.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/StderrPuts:
-  Exclude:
-    - 'bin/yarn'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -678,14 +678,6 @@ Style/StringLiteralsInInterpolation:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoredMethods.
-# IgnoredMethods: respond_to, define_method
-Style/SymbolProc:
-  Exclude:
-    - 'app/models/playlist.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -581,18 +581,6 @@ Style/MethodCallWithoutArgsParentheses:
   Exclude:
     - 'app/helpers/application_helper.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: require_parentheses, require_no_parentheses, require_no_parentheses_except_multiline
-Style/MethodDefParentheses:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/video.rb'
-    - 'lib/makigas/data_migrator.rb'
-    - 'lib/makigas/topic_import.rb'
-    - 'lib/makigas/video_import.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -615,16 +615,6 @@ Style/NestedParenthesizedCalls:
 Style/NumericLiterals:
   MinDigits: 15
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: PreferredDelimiters.
-Style/PercentLiteralDelimiters:
-  Exclude:
-    - 'config/deploy/production.rb'
-    - 'config/deploy/staging.rb'
-    - 'config/initializers/assets.rb'
-    - 'config/spring.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -568,12 +568,6 @@ Style/GuardClause:
   Exclude:
     - 'app/models/video.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/IfUnlessModifier:
-  Exclude:
-    - 'app/models/video.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -600,15 +600,6 @@ Style/MixinUsage:
     - 'bin/update'
     - 'spec/factories/playlists.rb'
 
-# Offense count: 28
-# Cop supports --auto-correct.
-# Configuration parameters: Whitelist.
-# Whitelist: be, be_a, be_an, be_between, be_falsey, be_kind_of, be_instance_of, be_truthy, be_within, eq, eql, end_with, include, match, raise_error, respond_to, start_with
-Style/NestedParenthesizedCalls:
-  Exclude:
-    - 'spec/helpers/application_helper_spec.rb'
-    - 'spec/helpers/dashboard/videos_helper_spec.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -671,13 +671,6 @@ Style/StringLiteralsInInterpolation:
     - 'lib/makigas/data_migrator.rb'
     - 'node_modules/node-sass/src/libsass/extconf.rb'
 
-# Offense count: 21
-# Cop supports --auto-correct.
-# Configuration parameters: MinSize.
-# SupportedStyles: percent, brackets
-Style/SymbolArray:
-  EnforcedStyle: brackets
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -638,16 +638,6 @@ Style/RedundantSelf:
     - 'app/models/video.rb'
     - 'config/environments/production.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, AllowInnerSlashes.
-# SupportedStyles: slashes, percent_r, mixed
-Style/RegexpLiteral:
-  Exclude:
-    - 'app/models/opinion.rb'
-    - 'app/models/playlist.rb'
-    - 'app/models/topic.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -465,22 +465,6 @@ Style/BlockComments:
   Exclude:
     - "spec/spec_helper.rb"
 
-# Offense count: 20
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# IgnoredMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - "spec/features/dashboard/opinions_spec.rb"
-    - "spec/features/dashboard/playlist_videos_spec.rb"
-    - "spec/features/dashboard/playlists_spec.rb"
-    - "spec/features/dashboard/topics_spec.rb"
-    - "spec/features/dashboard/videos_spec.rb"
-    - "spec/features/topics/topics_page_spec.rb"
-
 # Offense count: 14
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -520,17 +520,6 @@ Style/EmptyElse:
   Exclude:
     - "app/helpers/application_helper.rb"
 
-# Offense count: 6
-# Cop supports --auto-correct.
-Style/ExpandPathArguments:
-  Exclude:
-    - "Rakefile"
-    - "bin/bundle"
-    - "bin/rubocop"
-    - "bin/setup"
-    - "bin/update"
-    - "spec/rails_helper.rb"
-
 # Offense count: 124
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -661,16 +661,6 @@ Style/StderrPuts:
 Style/StringLiterals:
   Enabled: false
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiteralsInInterpolation:
-  Exclude:
-    - 'bin/yarn'
-    - 'lib/makigas/data_migrator.rb'
-    - 'node_modules/node-sass/src/libsass/extconf.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -512,14 +512,6 @@ Style/ColonMethodCall:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty, nil, both
-Style/EmptyElse:
-  Exclude:
-    - "app/helpers/application_helper.rb"
-
 # Offense count: 124
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -609,12 +609,6 @@ Style/NestedParenthesizedCalls:
     - 'spec/helpers/application_helper_spec.rb'
     - 'spec/helpers/dashboard/videos_helper_spec.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: Strict.
-Style/NumericLiterals:
-  MinDigits: 15
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -556,12 +556,6 @@ Style/FormatStringToken:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# Offense count: 2
-# Configuration parameters: AllowedVariables.
-Style/GlobalVars:
-  Exclude:
-    - 'node_modules/node-sass/src/libsass/extconf.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@
 # Include: **/*.gemfile, **/Gemfile, **/gems.rb
 Bundler/OrderedGems:
   Exclude:
-    - 'Gemfile'
+    - "Gemfile"
 
 # Offense count: 93
 # Cop supports --auto-correct.
@@ -26,9 +26,9 @@ Capybara/FeatureMethods:
 # SupportedStyles: with_first_argument, with_fixed_indentation
 Layout/ArgumentAlignment:
   Exclude:
-    - 'bin/rubocop'
-    - 'bin/webpack'
-    - 'bin/webpack-dev-server'
+    - "bin/rubocop"
+    - "bin/webpack"
+    - "bin/webpack-dev-server"
 
 # Offense count: 6
 # Cop supports --auto-correct.
@@ -38,14 +38,14 @@ Layout/ArgumentAlignment:
 # SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
 Layout/HashAlignment:
   Exclude:
-    - 'config/initializers/simple_form.rb'
-    - 'lib/makigas/video_import.rb'
+    - "config/initializers/simple_form.rb"
+    - "lib/makigas/video_import.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
 Layout/CommentIndentation:
   Exclude:
-    - 'app/controllers/users/sessions_controller.rb'
+    - "app/controllers/users/sessions_controller.rb"
 
 # Offense count: 4
 # Cop supports --auto-correct.
@@ -53,24 +53,24 @@ Layout/CommentIndentation:
 # SupportedStyles: leading, trailing
 Layout/DotPosition:
   Exclude:
-    - 'spec/models/video_spec.rb'
+    - "spec/models/video_spec.rb"
 
 # Offense count: 4
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterGuardClause:
   Exclude:
-    - 'lib/makigas/data_migrator.rb'
-    - 'lib/tasks/data_migrate.rake'
-    - 'lib/tasks/import_topics.rake'
-    - 'lib/tasks/import_videos.rake'
+    - "lib/makigas/data_migrator.rb"
+    - "lib/tasks/data_migrate.rake"
+    - "lib/tasks/import_topics.rake"
+    - "lib/tasks/import_videos.rake"
 
 # Offense count: 3
 # Cop supports --auto-correct.
 Layout/EmptyLines:
   Exclude:
-    - 'app/models/video.rb'
-    - 'bin/setup'
-    - 'db/migrate/20160625180750_devise_create_users.rb'
+    - "app/models/video.rb"
+    - "bin/setup"
+    - "db/migrate/20160625180750_devise_create_users.rb"
 
 # Offense count: 8
 # Cop supports --auto-correct.
@@ -78,12 +78,12 @@ Layout/EmptyLines:
 # SupportedStyles: empty_lines, no_empty_lines
 Layout/EmptyLinesAroundBlockBody:
   Exclude:
-    - 'db/migrate/20160626001601_create_playlists.rb'
-    - 'db/schema.rb'
-    - 'spec/models/opinion_spec.rb'
-    - 'spec/models/playlist_spec.rb'
-    - 'spec/models/topic_spec.rb'
-    - 'spec/models/user_spec.rb'
+    - "db/migrate/20160626001601_create_playlists.rb"
+    - "db/schema.rb"
+    - "spec/models/opinion_spec.rb"
+    - "spec/models/playlist_spec.rb"
+    - "spec/models/topic_spec.rb"
+    - "spec/models/user_spec.rb"
 
 # Offense count: 22
 # Cop supports --auto-correct.
@@ -91,19 +91,19 @@ Layout/EmptyLinesAroundBlockBody:
 # SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines, beginning_only, ending_only
 Layout/EmptyLinesAroundClassBody:
   Exclude:
-    - 'app/controllers/dashboard/dashboard_controller.rb'
-    - 'app/controllers/dashboard/opinions_controller.rb'
-    - 'app/controllers/dashboard/playlists_controller.rb'
-    - 'app/controllers/dashboard/topics_controller.rb'
-    - 'app/controllers/dashboard/users_controller.rb'
-    - 'app/controllers/dashboard/videos_controller.rb'
-    - 'app/controllers/playlists_controller.rb'
-    - 'app/controllers/topics_controller.rb'
-    - 'app/controllers/videos_controller.rb'
-    - 'app/models/video.rb'
-    - 'lib/makigas/data_migrator.rb'
-    - 'lib/makigas/topic_import.rb'
-    - 'lib/makigas/video_import.rb'
+    - "app/controllers/dashboard/dashboard_controller.rb"
+    - "app/controllers/dashboard/opinions_controller.rb"
+    - "app/controllers/dashboard/playlists_controller.rb"
+    - "app/controllers/dashboard/topics_controller.rb"
+    - "app/controllers/dashboard/users_controller.rb"
+    - "app/controllers/dashboard/videos_controller.rb"
+    - "app/controllers/playlists_controller.rb"
+    - "app/controllers/topics_controller.rb"
+    - "app/controllers/videos_controller.rb"
+    - "app/models/video.rb"
+    - "lib/makigas/data_migrator.rb"
+    - "lib/makigas/topic_import.rb"
+    - "lib/makigas/video_import.rb"
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -111,22 +111,22 @@ Layout/EmptyLinesAroundClassBody:
 # SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
 Layout/EmptyLinesAroundModuleBody:
   Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/videos_helper.rb'
+    - "app/helpers/application_helper.rb"
+    - "app/helpers/videos_helper.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: Width, IgnoredPatterns.
 Layout/IndentationWidth:
   Exclude:
-    - 'spec/features/front/front_videos_spec.rb'
+    - "spec/features/front/front_videos_spec.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: AllowDoxygenCommentStyle.
 Layout/LeadingCommentSpace:
   Exclude:
-    - 'node_modules/node-sass/src/libsass/extconf.rb'
+    - "node_modules/node-sass/src/libsass/extconf.rb"
 
 # Offense count: 4
 # Cop supports --auto-correct.
@@ -135,8 +135,8 @@ Layout/LeadingCommentSpace:
 # SupportedStylesForEmptyBrackets: space, no_space
 Layout/SpaceInsideArrayLiteralBrackets:
   Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'config/environments/production.rb'
+    - "app/helpers/application_helper.rb"
+    - "config/environments/production.rb"
 
 # Offense count: 14
 # Cop supports --auto-correct.
@@ -144,74 +144,74 @@ Layout/SpaceInsideArrayLiteralBrackets:
 # SupportedStyles: final_newline, final_blank_line
 Layout/TrailingEmptyLines:
   Exclude:
-    - 'app/models/application_record.rb'
-    - 'config/deploy/production.rb'
-    - 'config/initializers/session_store.rb'
-    - 'config/schedule.rb'
-    - 'lib/makigas/data_migrator.rb'
-    - 'lib/makigas/topic_import.rb'
-    - 'lib/makigas/video_import.rb'
-    - 'lib/tasks/data_migrate.rake'
-    - 'lib/tasks/export_topics.rake'
-    - 'lib/tasks/export_videos.rake'
-    - 'lib/tasks/import_topics.rake'
-    - 'lib/tasks/import_videos.rake'
-    - 'spec/features/dashboard/dashboard_spec.rb'
-    - 'spec/features/videos/video_page_spec.rb'
+    - "app/models/application_record.rb"
+    - "config/deploy/production.rb"
+    - "config/initializers/session_store.rb"
+    - "config/schedule.rb"
+    - "lib/makigas/data_migrator.rb"
+    - "lib/makigas/topic_import.rb"
+    - "lib/makigas/video_import.rb"
+    - "lib/tasks/data_migrate.rake"
+    - "lib/tasks/export_topics.rake"
+    - "lib/tasks/export_videos.rake"
+    - "lib/tasks/import_topics.rake"
+    - "lib/tasks/import_videos.rake"
+    - "spec/features/dashboard/dashboard_spec.rb"
+    - "spec/features/videos/video_page_spec.rb"
 
 # Offense count: 5
 # Cop supports --auto-correct.
 # Configuration parameters: AllowInHeredoc.
 Layout/TrailingWhitespace:
   Exclude:
-    - 'app/models/playlist.rb'
-    - 'app/models/user.rb'
-    - 'db/migrate/20170106104354_add_thumbnail_to_playlist.rb'
-    - 'db/migrate/20170106110213_add_thumbnail_to_topic.rb'
+    - "app/models/playlist.rb"
+    - "app/models/user.rb"
+    - "db/migrate/20170106104354_add_thumbnail_to_playlist.rb"
+    - "db/migrate/20170106110213_add_thumbnail_to_topic.rb"
 
 # Offense count: 4
 Lint/AmbiguousBlockAssociation:
   Exclude:
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
 
 # Offense count: 4
 Lint/AmbiguousOperator:
   Exclude:
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
 
 # Offense count: 3
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:
   Exclude:
-    - 'app/helpers/application_helper.rb'
+    - "app/helpers/application_helper.rb"
 
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:
   Exclude:
-    - 'lib/tasks/data_migrate.rake'
-    - 'lib/tasks/import_topics.rake'
-    - 'lib/tasks/import_videos.rake'
+    - "lib/tasks/data_migrate.rake"
+    - "lib/tasks/import_topics.rake"
+    - "lib/tasks/import_videos.rake"
 
 # Offense count: 5
 Lint/UselessAssignment:
   Exclude:
-    - 'spec/features/videos/videos_page_spec.rb'
-    - 'spec/models/playlist_spec.rb'
-    - 'spec/models/topic_spec.rb'
-    - 'spec/models/user_spec.rb'
+    - "spec/features/videos/videos_page_spec.rb"
+    - "spec/models/playlist_spec.rb"
+    - "spec/models/topic_spec.rb"
+    - "spec/models/user_spec.rb"
 
 # Offense count: 1
 # Configuration parameters: CheckForMethodsWithNoSideEffects.
 Lint/Void:
   Exclude:
-    - 'config/sitemap.rb'
+    - "config/sitemap.rb"
 
 # Offense count: 8
 Metrics/AbcSize:
@@ -233,23 +233,23 @@ Metrics/MethodLength:
 # AllowedNames: io, id, to, by, on, in, at, ip, db, os
 Naming/MethodParameterName:
   Exclude:
-    - 'lib/makigas/data_migrator.rb'
+    - "lib/makigas/data_migrator.rb"
 
 # Offense count: 30
 # Configuration parameters: Prefixes.
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/features/topics/topic_page_spec.rb'
-    - 'spec/features/videos/video_page_spec.rb'
-    - 'spec/features/videos/videos_search_spec.rb'
-    - 'spec/helpers/application_helper_spec.rb'
-    - 'spec/helpers/dashboard/videos_helper_spec.rb'
-    - 'spec/models/opinion_spec.rb'
-    - 'spec/models/playlist_spec.rb'
-    - 'spec/models/topic_spec.rb'
-    - 'spec/models/user_spec.rb'
-    - 'spec/models/video_spec.rb'
+    - "spec/features/topics/topic_page_spec.rb"
+    - "spec/features/videos/video_page_spec.rb"
+    - "spec/features/videos/videos_search_spec.rb"
+    - "spec/helpers/application_helper_spec.rb"
+    - "spec/helpers/dashboard/videos_helper_spec.rb"
+    - "spec/models/opinion_spec.rb"
+    - "spec/models/playlist_spec.rb"
+    - "spec/models/topic_spec.rb"
+    - "spec/models/user_spec.rb"
+    - "spec/models/video_spec.rb"
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -257,56 +257,56 @@ RSpec/ContextWording:
 # SupportedStyles: described_class, explicit
 RSpec/DescribedClass:
   Exclude:
-    - 'spec/models/video_spec.rb'
+    - "spec/models/video_spec.rb"
 
 # Offense count: 5
 # Cop supports --auto-correct.
 RSpec/EmptyLineAfterHook:
   Exclude:
-    - 'spec/features/dashboard/dashboard_spec.rb'
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
+    - "spec/features/dashboard/dashboard_spec.rb"
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlist_videos_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
 
 # Offense count: 4
 # Cop supports --auto-correct.
 RSpec/EmptyLineAfterSubject:
   Exclude:
-    - 'spec/models/video_spec.rb'
+    - "spec/models/video_spec.rb"
 
 # Offense count: 39
 # Configuration parameters: Max.
 RSpec/ExampleLength:
   Exclude:
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
-    - 'spec/features/front/front_videos_spec.rb'
-    - 'spec/features/playlists/playlist_page_spec.rb'
-    - 'spec/features/videos/video_page_spec.rb'
-    - 'spec/features/videos/videos_page_spec.rb'
-    - 'spec/features/videos/videos_search_spec.rb'
-    - 'spec/models/video_spec.rb'
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlist_videos_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
+    - "spec/features/front/front_videos_spec.rb"
+    - "spec/features/playlists/playlist_page_spec.rb"
+    - "spec/features/videos/video_page_spec.rb"
+    - "spec/features/videos/videos_page_spec.rb"
+    - "spec/features/videos/videos_search_spec.rb"
+    - "spec/models/video_spec.rb"
 
 # Offense count: 34
 # Cop supports --auto-correct.
 # Configuration parameters: CustomTransform, IgnoredWords.
 RSpec/ExampleWording:
   Exclude:
-    - 'spec/features/dashboard/dashboard_spec.rb'
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
-    - 'spec/features/topics/topics_page_spec.rb'
-    - 'spec/helpers/application_helper_spec.rb'
-    - 'spec/helpers/videos_helper_spec.rb'
-    - 'spec/models/topic_spec.rb'
-    - 'spec/models/video_spec.rb'
+    - "spec/features/dashboard/dashboard_spec.rb"
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlist_videos_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
+    - "spec/features/topics/topics_page_spec.rb"
+    - "spec/helpers/application_helper_spec.rb"
+    - "spec/helpers/videos_helper_spec.rb"
+    - "spec/models/topic_spec.rb"
+    - "spec/models/video_spec.rb"
 
 # Offense count: 13
 # Cop supports --auto-correct.
@@ -314,15 +314,15 @@ RSpec/ExampleWording:
 # SupportedStyles: method_call, block
 RSpec/ExpectChange:
   Exclude:
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
 
 # Offense count: 1
 RSpec/ExpectInHook:
   Exclude:
-    - 'spec/features/topics/topic_page_spec.rb'
+    - "spec/features/topics/topic_page_spec.rb"
 
 # Offense count: 11
 # Cop supports --auto-correct.
@@ -330,33 +330,33 @@ RSpec/ExpectInHook:
 # SupportedStyles: implicit, each, example
 RSpec/HookArgument:
   Exclude:
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
-    - 'spec/features/topics/topics_page_spec.rb'
-    - 'spec/features/videos/videos_search_spec.rb'
-    - 'spec/helpers/dashboard/videos_helper_spec.rb'
-    - 'spec/models/video_spec.rb'
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlist_videos_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
+    - "spec/features/topics/topics_page_spec.rb"
+    - "spec/features/videos/videos_search_spec.rb"
+    - "spec/helpers/dashboard/videos_helper_spec.rb"
+    - "spec/models/video_spec.rb"
 
 # Offense count: 207
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Exclude:
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
-    - 'spec/features/playlists/playlist_page_spec.rb'
-    - 'spec/features/playlists/playlists_page_spec.rb'
-    - 'spec/features/topics/topic_page_spec.rb'
-    - 'spec/features/topics/topics_page_spec.rb'
-    - 'spec/features/videos/video_page_spec.rb'
-    - 'spec/features/videos/videos_search_spec.rb'
-    - 'spec/helpers/dashboard/videos_helper_spec.rb'
-    - 'spec/models/video_spec.rb'
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlist_videos_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
+    - "spec/features/playlists/playlist_page_spec.rb"
+    - "spec/features/playlists/playlists_page_spec.rb"
+    - "spec/features/topics/topic_page_spec.rb"
+    - "spec/features/topics/topics_page_spec.rb"
+    - "spec/features/videos/video_page_spec.rb"
+    - "spec/features/videos/videos_search_spec.rb"
+    - "spec/helpers/dashboard/videos_helper_spec.rb"
+    - "spec/models/video_spec.rb"
 
 # Offense count: 52
 # Configuration parameters: AggregateFailuresByDefault.
@@ -366,83 +366,83 @@ RSpec/MultipleExpectations:
 # Offense count: 2
 RSpec/RepeatedDescription:
   Exclude:
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
+    - "spec/features/dashboard/playlist_videos_spec.rb"
 
 # Offense count: 2
 RSpec/ScatteredSetup:
   Exclude:
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
+    - "spec/features/dashboard/playlist_videos_spec.rb"
 
 # Offense count: 10
 # Cop supports --auto-correct.
 Rails/ActiveRecordAliases:
   Exclude:
-    - 'app/controllers/dashboard/opinions_controller.rb'
-    - 'app/controllers/dashboard/playlists_controller.rb'
-    - 'app/controllers/dashboard/topics_controller.rb'
-    - 'app/controllers/dashboard/users_controller.rb'
-    - 'app/controllers/dashboard/videos_controller.rb'
-    - 'spec/features/front/front_opinions_spec.rb'
-    - 'spec/features/videos/video_page_spec.rb'
+    - "app/controllers/dashboard/opinions_controller.rb"
+    - "app/controllers/dashboard/playlists_controller.rb"
+    - "app/controllers/dashboard/topics_controller.rb"
+    - "app/controllers/dashboard/users_controller.rb"
+    - "app/controllers/dashboard/videos_controller.rb"
+    - "spec/features/front/front_opinions_spec.rb"
+    - "spec/features/videos/video_page_spec.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
 Rails/BelongsTo:
   Exclude:
-    - 'app/models/playlist.rb'
+    - "app/models/playlist.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: NilOrEmpty, NotPresent, UnlessPresent.
 Rails/Blank:
   Exclude:
-    - 'lib/tasks/reset_minio_policy.rake'
+    - "lib/tasks/reset_minio_policy.rake"
 
 # Offense count: 15
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: slashes, arguments
 Rails/FilePath:
   Exclude:
-    - 'config/application.rb'
-    - 'config/environments/development.rb'
-    - 'spec/factories/opinions.rb'
-    - 'spec/factories/playlists.rb'
-    - 'spec/factories/topics.rb'
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
+    - "config/application.rb"
+    - "config/environments/development.rb"
+    - "spec/factories/opinions.rb"
+    - "spec/factories/playlists.rb"
+    - "spec/factories/topics.rb"
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
 
 # Offense count: 1
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
 Rails/InverseOf:
   Exclude:
-    - 'app/models/playlist.rb'
+    - "app/models/playlist.rb"
 
 # Offense count: 7
 # Configuration parameters: Include.
 # Include: app/controllers/**/*.rb
 Rails/LexicallyScopedActionFilter:
   Exclude:
-    - 'app/controllers/dashboard/opinions_controller.rb'
-    - 'app/controllers/dashboard/playlists_controller.rb'
-    - 'app/controllers/dashboard/topics_controller.rb'
-    - 'app/controllers/dashboard/users_controller.rb'
-    - 'app/controllers/dashboard/videos_controller.rb'
-    - 'app/controllers/playlists_controller.rb'
-    - 'app/controllers/topics_controller.rb'
+    - "app/controllers/dashboard/opinions_controller.rb"
+    - "app/controllers/dashboard/playlists_controller.rb"
+    - "app/controllers/dashboard/topics_controller.rb"
+    - "app/controllers/dashboard/users_controller.rb"
+    - "app/controllers/dashboard/videos_controller.rb"
+    - "app/controllers/playlists_controller.rb"
+    - "app/controllers/topics_controller.rb"
 
 # Offense count: 1
 Rails/OutputSafety:
   Exclude:
-    - 'app/helpers/application_helper.rb'
+    - "app/helpers/application_helper.rb"
 
 # Offense count: 1
 # Configuration parameters: Blacklist, Whitelist.
 # Blacklist: decrement!, decrement_counter, increment!, increment_counter, toggle!, touch, update_all, update_attribute, update_column, update_columns, update_counters
 Rails/SkipsModelValidations:
   Exclude:
-    - 'db/migrate/20170227184939_add_published_at_to_videos.rb'
+    - "db/migrate/20170227184939_add_published_at_to_videos.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -450,20 +450,20 @@ Rails/SkipsModelValidations:
 # SupportedStyles: strict, flexible
 Rails/TimeZone:
   Exclude:
-    - 'lib/makigas/video_import.rb'
+    - "lib/makigas/video_import.rb"
 
 # Offense count: 2
 # Cop supports --auto-correct.
 Security/YAMLLoad:
   Exclude:
-    - 'lib/makigas/topic_import.rb'
-    - 'lib/makigas/video_import.rb'
+    - "lib/makigas/topic_import.rb"
+    - "lib/makigas/video_import.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/BlockComments:
   Exclude:
-    - 'spec/spec_helper.rb'
+    - "spec/spec_helper.rb"
 
 # Offense count: 20
 # Cop supports --auto-correct.
@@ -474,12 +474,12 @@ Style/BlockComments:
 # IgnoredMethods: lambda, proc, it
 Style/BlockDelimiters:
   Exclude:
-    - 'spec/features/dashboard/opinions_spec.rb'
-    - 'spec/features/dashboard/playlist_videos_spec.rb'
-    - 'spec/features/dashboard/playlists_spec.rb'
-    - 'spec/features/dashboard/topics_spec.rb'
-    - 'spec/features/dashboard/videos_spec.rb'
-    - 'spec/features/topics/topics_page_spec.rb'
+    - "spec/features/dashboard/opinions_spec.rb"
+    - "spec/features/dashboard/playlist_videos_spec.rb"
+    - "spec/features/dashboard/playlists_spec.rb"
+    - "spec/features/dashboard/topics_spec.rb"
+    - "spec/features/dashboard/videos_spec.rb"
+    - "spec/features/topics/topics_page_spec.rb"
 
 # Offense count: 14
 # Cop supports --auto-correct.
@@ -487,26 +487,26 @@ Style/BlockDelimiters:
 # SupportedStyles: nested, compact
 Style/ClassAndModuleChildren:
   Exclude:
-    - 'app/controllers/dashboard/dashboard_controller.rb'
-    - 'app/controllers/dashboard/opinions_controller.rb'
-    - 'app/controllers/dashboard/playlists_controller.rb'
-    - 'app/controllers/dashboard/topics_controller.rb'
-    - 'app/controllers/dashboard/users_controller.rb'
-    - 'app/controllers/dashboard/videos_controller.rb'
-    - 'app/controllers/users/passwords_controller.rb'
-    - 'app/controllers/users/sessions_controller.rb'
-    - 'app/controllers/users/unlocks_controller.rb'
-    - 'app/helpers/dashboard/opinions_helper.rb'
-    - 'app/helpers/dashboard/videos_helper.rb'
-    - 'lib/makigas/data_migrator.rb'
-    - 'lib/makigas/topic_import.rb'
-    - 'lib/makigas/video_import.rb'
+    - "app/controllers/dashboard/dashboard_controller.rb"
+    - "app/controllers/dashboard/opinions_controller.rb"
+    - "app/controllers/dashboard/playlists_controller.rb"
+    - "app/controllers/dashboard/topics_controller.rb"
+    - "app/controllers/dashboard/users_controller.rb"
+    - "app/controllers/dashboard/videos_controller.rb"
+    - "app/controllers/users/passwords_controller.rb"
+    - "app/controllers/users/sessions_controller.rb"
+    - "app/controllers/users/unlocks_controller.rb"
+    - "app/helpers/dashboard/opinions_helper.rb"
+    - "app/helpers/dashboard/videos_helper.rb"
+    - "lib/makigas/data_migrator.rb"
+    - "lib/makigas/topic_import.rb"
+    - "lib/makigas/video_import.rb"
 
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/ColonMethodCall:
   Exclude:
-    - 'lib/makigas/data_migrator.rb'
+    - "lib/makigas/data_migrator.rb"
 
 # Offense count: 42
 Style/Documentation:
@@ -518,27 +518,18 @@ Style/Documentation:
 # SupportedStyles: empty, nil, both
 Style/EmptyElse:
   Exclude:
-    - 'app/helpers/application_helper.rb'
+    - "app/helpers/application_helper.rb"
 
 # Offense count: 6
 # Cop supports --auto-correct.
 Style/ExpandPathArguments:
   Exclude:
-    - 'Rakefile'
-    - 'bin/bundle'
-    - 'bin/rubocop'
-    - 'bin/setup'
-    - 'bin/update'
-    - 'spec/rails_helper.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: format, sprintf, percent
-Style/FormatString:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/video.rb'
+    - "Rakefile"
+    - "bin/bundle"
+    - "bin/rubocop"
+    - "bin/setup"
+    - "bin/update"
+    - "spec/rails_helper.rb"
 
 # Offense count: 124
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -562,12 +562,6 @@ Style/GlobalVars:
   Exclude:
     - 'node_modules/node-sass/src/libsass/extconf.rb'
 
-# Offense count: 1
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'app/models/video.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -459,12 +459,6 @@ Security/YAMLLoad:
     - "lib/makigas/topic_import.rb"
     - "lib/makigas/video_import.rb"
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/BlockComments:
-  Exclude:
-    - "spec/spec_helper.rb"
-
 # Offense count: 14
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -631,13 +631,6 @@ Style/RedundantBegin:
   Exclude:
     - 'bin/yarn'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/RedundantSelf:
-  Exclude:
-    - 'app/models/video.rb'
-    - 'config/environments/production.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -480,10 +480,6 @@ Style/ClassAndModuleChildren:
     - "lib/makigas/topic_import.rb"
     - "lib/makigas/video_import.rb"
 
-# Offense count: 42
-Style/Documentation:
-  Enabled: false
-
 # Offense count: 124
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -593,13 +593,6 @@ Style/MethodDefParentheses:
     - 'lib/makigas/topic_import.rb'
     - 'lib/makigas/video_import.rb'
 
-# Offense count: 3
-Style/MixinUsage:
-  Exclude:
-    - 'bin/setup'
-    - 'bin/update'
-    - 'spec/factories/playlists.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -540,15 +540,6 @@ Style/FormatString:
     - 'app/helpers/application_helper.rb'
     - 'app/models/video.rb'
 
-# Offense count: 12
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: annotated, template, unannotated
-Style/FormatStringToken:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/video.rb'
-    - 'config/routes.rb'
-
 # Offense count: 124
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -480,12 +480,6 @@ Style/ClassAndModuleChildren:
     - "lib/makigas/topic_import.rb"
     - "lib/makigas/video_import.rb"
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/ColonMethodCall:
-  Exclude:
-    - "lib/makigas/data_migrator.rb"
-
 # Offense count: 42
 Style/Documentation:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -574,13 +574,6 @@ Style/IfUnlessModifier:
   Exclude:
     - 'app/models/video.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoredMethods.
-Style/MethodCallWithoutArgsParentheses:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -686,14 +686,6 @@ Style/SymbolProc:
   Exclude:
     - 'app/models/playlist.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Exclude:
-    - 'app/models/playlist.rb'
-
 # Offense count: 167
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/Capfile
+++ b/Capfile
@@ -1,20 +1,20 @@
 # Load DSL and set up stages
-require "capistrano/setup"
+require 'capistrano/setup'
 
 # Include default deployment tasks
-require "capistrano/deploy"
+require 'capistrano/deploy'
 
 # Load the SCM plugin appropriate to your project:
-require "capistrano/scm/git"
+require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 
 # Include tasks from other gems included in your Gemfile
-require "capistrano/rvm"
-require "capistrano/bundler"
-require "capistrano/rails/assets"
-require "capistrano/rails/migrations"
-require "capistrano/sitemap_generator"
-require "whenever/capistrano"
+require 'capistrano/rvm'
+require 'capistrano/bundler'
+require 'capistrano/rails/assets'
+require 'capistrano/rails/migrations'
+require 'capistrano/sitemap_generator'
+require 'whenever/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
-Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/app/controllers/dashboard/opinions_controller.rb
+++ b/app/controllers/dashboard/opinions_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::OpinionsController < Dashboard::DashboardController
 
-  before_action :opinion_set, only: [:show, :edit, :update, :destroy]
+  before_action :opinion_set, only: %i[show edit update destroy]
 
   def index
     @opinions = Opinion.order(updated_at: :desc).page(params[:page])
@@ -13,7 +13,7 @@ class Dashboard::OpinionsController < Dashboard::DashboardController
   def create
     @opinion = Opinion.new(opinion_params)
     if @opinion.save
-      redirect_to [:dashboard, :opinions], notice: t('.created')
+      redirect_to %i[dashboard opinions], notice: t('.created')
     else
       render :new
     end
@@ -21,7 +21,7 @@ class Dashboard::OpinionsController < Dashboard::DashboardController
 
   def update
     if @opinion.update_attributes(opinion_params)
-      redirect_to [:dashboard, :opinions], notice: t('.updated')
+      redirect_to %i[dashboard opinions], notice: t('.updated')
     else
       render :edit
     end
@@ -29,7 +29,7 @@ class Dashboard::OpinionsController < Dashboard::DashboardController
 
   def destroy
     @opinion.destroy!
-    redirect_to [:dashboard, :opinions], notice: t('.destroyed')
+    redirect_to %i[dashboard opinions], notice: t('.destroyed')
   end
 
   private

--- a/app/controllers/dashboard/playlists_controller.rb
+++ b/app/controllers/dashboard/playlists_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::PlaylistsController < Dashboard::DashboardController
 
-  before_action :playlist_set, only: [:show, :edit, :update, :destroy, :videos]
+  before_action :playlist_set, only: %i[show edit update destroy videos]
 
   def index
     @playlists = Playlist.order(updated_at: :desc).page(params[:page])
@@ -29,7 +29,7 @@ class Dashboard::PlaylistsController < Dashboard::DashboardController
 
   def destroy
     @playlist.destroy!
-    redirect_to [:dashboard, :playlists], notice: t('.destroyed')
+    redirect_to %i[dashboard playlists], notice: t('.destroyed')
   end
 
   def videos

--- a/app/controllers/dashboard/topics_controller.rb
+++ b/app/controllers/dashboard/topics_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::TopicsController < Dashboard::DashboardController
 
-  before_action :topic_set, only: [:show, :edit, :update, :destroy]
+  before_action :topic_set, only: %i[show edit update destroy]
 
   def index
     @topics = Topic.order(updated_at: :desc).page(params[:page])
@@ -29,7 +29,7 @@ class Dashboard::TopicsController < Dashboard::DashboardController
 
   def destroy
     @topic.destroy!
-    redirect_to [:dashboard, :topics], notice: t('.destroyed')
+    redirect_to %i[dashboard topics], notice: t('.destroyed')
   end
 
   private

--- a/app/controllers/dashboard/users_controller.rb
+++ b/app/controllers/dashboard/users_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::UsersController < Dashboard::DashboardController
 
-  before_action :user_set, only: [:show, :edit, :update, :destroy]
+  before_action :user_set, only: %i[show edit update destroy]
 
   def index
     @users = User.all.page(params[:page])
@@ -30,9 +30,9 @@ class Dashboard::UsersController < Dashboard::DashboardController
   def destroy
     if @user != current_user
       @user.destroy!
-      redirect_to [:dashboard, :users], notice: t('.destroyed')
+      redirect_to %i[dashboard users], notice: t('.destroyed')
     else
-      redirect_to [:dashboard, :users], error: t('.current_user')
+      redirect_to %i[dashboard users], error: t('.current_user')
     end
   end
 

--- a/app/controllers/dashboard/videos_controller.rb
+++ b/app/controllers/dashboard/videos_controller.rb
@@ -34,13 +34,13 @@ class Dashboard::VideosController < Dashboard::DashboardController
 
   def move
     respond_to do |format|
-      if params[:direction] == "up"
+      if params[:direction] == 'up'
         @video.move_higher
-        format.json { render json: { position: @video.position, direction: "up" } }
+        format.json { render json: { position: @video.position, direction: 'up' } }
         format.html { redirect_to [:videos, :dashboard, @video.playlist], notice: t('.moved') }
-      elsif params[:direction] == "down"
+      elsif params[:direction] == 'down'
         @video.move_lower
-        format.json { render json: { position: @video.position, direction: "down" } }
+        format.json { render json: { position: @video.position, direction: 'down' } }
         format.html { redirect_to [:videos, :dashboard, @video.playlist], notice: t('.moved') }
       end
     end

--- a/app/controllers/dashboard/videos_controller.rb
+++ b/app/controllers/dashboard/videos_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::VideosController < Dashboard::DashboardController
 
-  before_action :video_set, only: [:show, :edit, :update, :destroy, :move]
+  before_action :video_set, only: %i[show edit update destroy move]
 
   def index
     @videos = Video.order(created_at: :desc).page(params[:page])
@@ -29,7 +29,7 @@ class Dashboard::VideosController < Dashboard::DashboardController
 
   def destroy
     @video.destroy!
-    redirect_to [:dashboard, :videos], notice: t('.destroyed')
+    redirect_to %i[dashboard videos], notice: t('.destroyed')
   end
 
   def move

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -1,6 +1,6 @@
 class PlaylistsController < ApplicationController
 
-  before_action :playlist_set, only: [:show, :feed]
+  before_action :playlist_set, only: %i[show feed]
 
   def index
     @playlists = Playlist.all.order(created_at: :desc)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,6 @@
 class TopicsController < ApplicationController
 
-  before_action :topic_set, only: [:show, :feed]
+  before_action :topic_set, only: %i[show feed]
 
   def index
     @topics = Topic.all

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,5 +1,5 @@
 class Users::PasswordsController < Devise::PasswordsController
-  layout "devise"
+  layout 'devise'
   # GET /resource/password/new
   # def new
   #   super

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Users::SessionsController < Devise::SessionsController
-  layout "devise"
+  layout 'devise'
 # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -3,9 +3,9 @@ class VideosController < ApplicationController
   def index
     @videos = Video.visible.joins(:playlist).all
     if params[:length]
-      @videos = @videos.where('duration <= 300') if params[:length] == "short"
-      @videos = @videos.where('duration > 300 and duration <= 900') if params[:length] == "medium"
-      @videos = @videos.where('duration > 900') if params[:length] == "long"
+      @videos = @videos.where('duration <= 300') if params[:length] == 'short'
+      @videos = @videos.where('duration > 300 and duration <= 900') if params[:length] == 'medium'
+      @videos = @videos.where('duration > 900') if params[:length] == 'long'
     end
     @videos = @videos.where(playlists: { topic_id: Topic.where(slug: params[:topic]).pluck(:id) }) if params[:topic]
     @videos = @videos.order(created_at: :desc).page(params[:page]).per 10

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,8 +29,6 @@ module ApplicationHelper
     elsif match = sec.match(/^([0-5]?[0-9])$/)
       seconds = match.captures[0]
       seconds.to_i
-    else
-      nil
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
   end
 
   def to_markdown(text)
-    render = Redcarpet::Render::HTML.new()
+    render = Redcarpet::Render::HTML.new
     markdown = Redcarpet::Markdown.new(render)
     markdown.render(text).html_safe
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
 
-  def paginate objects, options = {}
+  def paginate(objects, options = {})
     options.reverse_merge!(theme: 'twitter-bootstrap-3')
     super(objects, options)
   end
@@ -10,7 +10,7 @@ module ApplicationHelper
     url_for only_path: false, params: parameters
   end
 
-  def running_time sec, options = {}
+  def running_time(sec, options = {})
     if sec >= 3600 || (!options[:full].nil? && options[:full] == true)
       '%d:%02d:%02d' % [ sec / 3600, (sec % 3600) / 60, sec % 60]
     else
@@ -18,7 +18,7 @@ module ApplicationHelper
     end
   end
 
-  def extract_time sec
+  def extract_time(sec)
     if match = sec.match(/^([0-9]+):([0-5][0-9]):([0-5][0-9])$/)
       hours, minutes, seconds = match.captures
       hours.to_i * 3600 + minutes.to_i * 60 + seconds.to_i
@@ -33,7 +33,7 @@ module ApplicationHelper
     end
   end
 
-  def to_markdown text
+  def to_markdown(text)
     render = Redcarpet::Render::HTML.new()
     markdown = Redcarpet::Markdown.new(render)
     markdown.render(text).html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,11 +11,12 @@ module ApplicationHelper
   end
 
   def running_time(sec, options = {})
-    if sec >= 3600 || (!options[:full].nil? && options[:full] == true)
-      '%d:%02d:%02d' % [ sec / 3600, (sec % 3600) / 60, sec % 60]
-    else
-      '%d:%02d' % [ sec / 60, sec % 60]
-    end
+    times = if sec >= 3600 || (!options[:full].nil? && options[:full] == true)
+              [ sec / 3600, (sec % 3600) / 60, sec % 60]
+            else
+              [ sec / 60, sec % 60]
+            end
+    format_as_timestamp(times)
   end
 
   def extract_time(sec)
@@ -41,5 +42,12 @@ module ApplicationHelper
 
   def dnt_requested
     request.headers.include?('DNT') && request.headers['DNT'].starts_with?('1')
+  end
+
+  private
+
+  def format_as_timestamp(value_list)
+    first, *remain = value_list
+    first.to_s + ':' + remain.map { |val| val.to_s.rjust(2, '0') }.join(':')
   end
 end

--- a/app/models/opinion.rb
+++ b/app/models/opinion.rb
@@ -7,7 +7,7 @@ class Opinion < ApplicationRecord
   validates :from, presence: true, length: { maximum: 50 }
   validates :message, presence: true, length: { maximum: 200 }
   validates :photo, presence: true
-  validates_attachment :photo, content_type: { content_type: /\Aimage\/.*\z/ }
+  validates_attachment :photo, content_type: { content_type: %r{\Aimage/.*\z} }
 
   def to_s
     from

--- a/app/models/opinion.rb
+++ b/app/models/opinion.rb
@@ -1,7 +1,7 @@
 class Opinion < ApplicationRecord
   has_attached_file :photo, styles: {
-    default: "320x320>",
-    small: "160x160>"
+    default: '320x320>',
+    small: '160x160>'
   }
 
   validates :from, presence: true, length: { maximum: 50 }

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -21,8 +21,8 @@ class Playlist < ApplicationRecord
   validates :youtube_id, presence: true, length: { maximum: 100 }
   validates :thumbnail, presence: true
   validates :card, presence: true
-  validates_attachment :thumbnail, content_type: { content_type: /\Aimage\/.*\z/ }
-  validates_attachment :card, content_type: { content_type: /\Aimage\/.*\z/ }
+  validates_attachment :thumbnail, content_type: { content_type: %r{\Aimage/.*\z} }
+  validates_attachment :card, content_type: { content_type: %r{\Aimage/.*\z} }
 
   has_many :videos, -> { order(position: :asc) }
   belongs_to :topic, required: false

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -4,16 +4,16 @@ class Playlist < ApplicationRecord
   friendly_id :title, use: :slugged
 
   has_attached_file :thumbnail, styles: {
-    thumbnail: "100x100>",
-    small: "180x180>",
-    default: "360x360>",
-    hidef: "720x720>"
-  }, default_url: "/makigas.png"
+    thumbnail: '100x100>',
+    small: '180x180>',
+    default: '360x360>',
+    hidef: '720x720>'
+  }, default_url: '/makigas.png'
   
   has_attached_file :card, styles: {
-    thumbnail: "320x180>",
-    small: "640x360>",
-    default: "1280x720>"
+    thumbnail: '320x180>',
+    small: '640x360>',
+    default: '1280x720>'
   }
 
   validates :title, presence: true, length: { maximum: 100 }

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -13,7 +13,7 @@ class Playlist < ApplicationRecord
   has_attached_file :card, styles: {
     thumbnail: "320x180>",
     small: "640x360>",
-    default: "1280x720>",
+    default: "1280x720>"
   }
 
   validates :title, presence: true, length: { maximum: 100 }

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -28,7 +28,7 @@ class Playlist < ApplicationRecord
   belongs_to :topic, required: false
   
   def total_length
-    videos.map { |v| v.duration }.reduce(0, :+)
+    videos.map(&:duration).reduce(0, :+)
   end
 
   def to_s

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -14,7 +14,7 @@ class Topic < ApplicationRecord
   validates :description, presence: true, length: { maximum: 250 }
   validates :color, presence: true
   validates :thumbnail, presence: true
-  validates_attachment :thumbnail, content_type: { content_type: /\Aimage\/.*\z/ }
+  validates_attachment :thumbnail, content_type: { content_type: %r{\Aimage/.*\z} }
 
   # Playlists can survive without a topic, so on delete set the topic to null.
   has_many :playlists, dependent: :nullify

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,11 +4,11 @@ class Topic < ApplicationRecord
   friendly_id :title, use: :slugged
 
   has_attached_file :thumbnail, styles: {
-    thumbnail: "100x100>",
-    small: "180x180>",
-    default: "360x360>",
-    hidef: "720x720>"
-  }, default_url: "/makigas.png"
+    thumbnail: '100x100>',
+    small: '180x180>',
+    default: '360x360>',
+    hidef: '720x720>'
+  }, default_url: '/makigas.png'
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, presence: true, length: { maximum: 250 }

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -27,10 +27,8 @@ class Video < ApplicationRecord
   def natural_duration
     return nil if duration.blank?
 
-    hours = duration / 3600
-    minutes = duration % 3600
-    seconds = duration % 60
-    [hours.to_s.rjust(2, '0'), minutes.to_s.rjust(2, '0'), seconds.to_s.rjust(2, '0')].join(':')
+    timestamps = [duration / 3600, (duration % 3600) / 60, duration % 60]
+    timestamps.map { |ts| ts.to_s.rjust(2, '0') }.join(':')
   end
 
   # Visible videos are those whose publication date has been already reached.

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -26,7 +26,7 @@ class Video < ApplicationRecord
 
   def natural_duration
     if duration
-      "%02d:%02d:%02d" % [duration / 3600, (duration % 3600) / 60, duration % 60]
+      '%02d:%02d:%02d' % [duration / 3600, (duration % 3600) / 60, duration % 60]
     end
   end
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -33,14 +33,14 @@ class Video < ApplicationRecord
   # Visible videos are those whose publication date has been already reached.
   # Therefore this videos are visible on lists, playlists, searches...
   def visible?
-    self.published_at <= DateTime.now
+    published_at <= DateTime.now
   end
 
   # Scheduled videos are those whose publication date has not been reached yet.
   # Showing content for this video would spoil the experience and therefore
   # they should be excluded from searches, lists, playlists...
   def scheduled?
-    self.published_at > DateTime.now
+    published_at > DateTime.now
   end
 
   def to_s

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -20,7 +20,7 @@ class Video < ApplicationRecord
   validates :published_at, presence: true
 
   # Natural duration
-  def natural_duration= dur
+  def natural_duration=(dur)
     self.duration = ApplicationController.helpers.extract_time dur
   end
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -6,7 +6,7 @@ class Video < ApplicationRecord
   acts_as_list scope: :playlist
 
   # Slug. Can be repeated as long as it's on different playlists.
-  friendly_id :title, use: [:slugged, :scoped], scope: :playlist
+  friendly_id :title, use: %i[slugged scoped], scope: :playlist
 
   # Scope for limiting the amount of videos to those actually published.
   scope :visible, -> { where('published_at <= ?', DateTime.now) }

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -25,9 +25,7 @@ class Video < ApplicationRecord
   end
 
   def natural_duration
-    if duration
-      '%02d:%02d:%02d' % [duration / 3600, (duration % 3600) / 60, duration % 60]
-    end
+    '%02d:%02d:%02d' % [duration / 3600, (duration % 3600) / 60, duration % 60] if duration
   end
 
   # Visible videos are those whose publication date has been already reached.

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -25,7 +25,12 @@ class Video < ApplicationRecord
   end
 
   def natural_duration
-    '%02d:%02d:%02d' % [duration / 3600, (duration % 3600) / 60, duration % 60] if duration
+    return nil if duration.blank?
+
+    hours = duration / 3600
+    minutes = duration % 3600
+    seconds = duration % 60
+    [hours.to_s.rjust(2, '0'), minutes.to_s.rjust(2, '0'), seconds.to_s.rjust(2, '0')].join(':')
   end
 
   # Visible videos are those whose publication date has been already reached.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock "3.11.2"
+lock '3.11.2'
 
 # Keep sensitive deployment informatino out of the repo. As seen on:
 # https://github.com/AyuntamientoMadrid/transparencia/blob/master/config/deploy.rb
@@ -9,7 +9,7 @@ def deploy_param(key)
 end
 
 # Deploy settings
-set :application, "makigas"
+set :application, 'makigas'
 set :deploy_to, deploy_param(:deploy_to)
 set :repo_url, deploy_param(:repo_url)
 
@@ -24,8 +24,8 @@ namespace :deploy do
 end
 
 # Shared settings
-append :linked_files, ".env"
-append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
+append :linked_files, '.env'
+append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system'
 
 # Misc settings
 after 'deploy:finishing', 'deploy:cleanup'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,5 @@
 # Server to deploy to.
-server deploy_param(:server), user: deploy_param(:user), roles: %w{app db web}
+server deploy_param(:server), user: deploy_param(:user), roles: %w[app db web]
 
 # Deployment branch
 set :branch, deploy_param(:branch)

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
 # Server to deploy to.
-server deploy_param(:server), user: deploy_param(:user), roles: %w{app db web}
+server deploy_param(:server), user: deploy_param(:user), roles: %w[app db web]
 
 # Deployment branch
 set :branch, deploy_param(:branch)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,5 +58,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  Paperclip.options[:command_path] = "/usr/local/bin/"
+  Paperclip.options[:command_path] = '/usr/local/bin/'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,8 +11,8 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w(
+Rails.application.config.assets.precompile += %w[
   dashboard/dashboard.css
   dashboard/dashboard.js
   devise/devise.css
-)
+]

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,4 +1,4 @@
-if ENV["RAILS_USE_S3"].present?
+if ENV['RAILS_USE_S3'].present?
   # Base settings, they work on all cases.
   Paperclip::Attachment.default_options.update(
     storage: :s3,

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,19 +4,19 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -1,10 +1,10 @@
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+workers ENV.fetch('WEB_CONCURRENCY') { 2 }
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 threads threads_count, threads_count
 
 preload_app!
 
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 bind 'unix://tmp/sockets/puma.sock'
 pidfile 'tmp/pids/puma.pid'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,10 @@ Rails.application.routes.draw do
     namespace :dashboard, path: '' do
       root to: 'dashboard#index', as: ''
       resources :topics
-      resources :videos, only: [:index, :new, :create]
+      resources :videos, only: %i[index new create]
       resources :playlists do
         get :videos, on: :member
-        resources :videos, except: [:index, :new, :create] do
+        resources :videos, except: %i[index new create] do
           put :move, on: :member
         end
       end
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   # Main application routes
   root to: 'front#index'
 
-  resources :topics, only: [:index, :show], constraints: { format: :html } do
+  resources :topics, only: %i[index show], constraints: { format: :html } do
     get :feed, on: :member
   end
 
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
     get :feed, on: :collection
   end
 
-  resources :playlists, path: 'series', only: [:index, :show], constraints: { format: :html } do
+  resources :playlists, path: 'series', only: %i[index show], constraints: { format: :html } do
     get :feed, on: :member
     resources :videos, path: '/', only: [:show], constraints: { format: :html }
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-set :output, "/var/log/makigas.cron.log"
+set :output, '/var/log/makigas.cron.log'
 
 every :day, at: '5am' do
   rake '-s sitemap:refresh'

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,5 +1,5 @@
 # Set the host name for URL creation
-SitemapGenerator::Sitemap.default_host = "https://www.makigas.es"
+SitemapGenerator::Sitemap.default_host = 'https://www.makigas.es'
 SitemapGenerator::Sitemap
 
 SitemapGenerator::Sitemap.create do

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
-%w(
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }

--- a/db/migrate/20160625180750_devise_create_users.rb
+++ b/db/migrate/20160625180750_devise_create_users.rb
@@ -2,8 +2,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token

--- a/lib/makigas/data_migrator.rb
+++ b/lib/makigas/data_migrator.rb
@@ -95,7 +95,7 @@ class Makigas::DataMigrator
     video.position = v["position"]
     video.created_at = v["created_at"]
     video.playlist = playlist
-    File.open(File.join(@thumbnails, "#{v["youtube_id"]}.jpg")) do |f|
+    File.open(File.join(@thumbnails, "#{v['youtube_id']}.jpg")) do |f|
       video.thumbnail = f
     end
     video.save

--- a/lib/makigas/data_migrator.rb
+++ b/lib/makigas/data_migrator.rb
@@ -28,7 +28,7 @@ require 'json'
 class Makigas::DataMigrator
 
   def initialize(schema, thumbnails)
-    raise 'Not a thumbnails folder' unless File::directory?(thumbnails)
+    raise 'Not a thumbnails folder' unless File.directory?(thumbnails)
     @schema = JSON.parse!(File.read(schema))
     @thumbnails = thumbnails
   end

--- a/lib/makigas/data_migrator.rb
+++ b/lib/makigas/data_migrator.rb
@@ -27,7 +27,7 @@ require 'json'
 # The migrator will paste the first playlist photo as the photo for the topic.
 class Makigas::DataMigrator
 
-  def initialize schema, thumbnails
+  def initialize(schema, thumbnails)
     raise 'Not a thumbnails folder' unless File::directory?(thumbnails)
     @schema = JSON.parse!(File.read(schema))
     @thumbnails = thumbnails
@@ -44,7 +44,7 @@ class Makigas::DataMigrator
   # This method will load into the database the contents for a topic,
   # including playlists associated with that topic, including videos
   # associated with that playlist.
-  def load_topic! t
+  def load_topic!(t)
     # Thumbnail is taken from the first episode of the first playlist.
     thumbnail = t['playlists'][0]['videos'][0]['youtube_id']
 
@@ -64,7 +64,7 @@ class Makigas::DataMigrator
 
   # This method will load into the database the contents for a playlist
   # +p+ and associate it as a playlist part of the Topic object +topic+.
-  def load_playlist! p, topic
+  def load_playlist!(p, topic)
     # Thumbnail is taken from the first episode of the playlist
     thumbnail = p['videos'][0]['youtube_id']
 
@@ -86,7 +86,7 @@ class Makigas::DataMigrator
 
   # This method will load into the database the contents for a video +v+
   # and associate it as a video part of the Playlist object +playlist+.
-  def load_video! v, playlist
+  def load_video!(v, playlist)
     video = Video.new
     video.title = v['title']
     video.description = v['description'].split('\n')[0]

--- a/lib/makigas/data_migrator.rb
+++ b/lib/makigas/data_migrator.rb
@@ -46,34 +46,34 @@ class Makigas::DataMigrator
   # associated with that playlist.
   def load_topic! t
     # Thumbnail is taken from the first episode of the first playlist.
-    thumbnail = t["playlists"][0]["videos"][0]["youtube_id"]
+    thumbnail = t['playlists'][0]['videos'][0]['youtube_id']
 
     # Create the topic.
     topic = Topic.new
-    topic.title = t["title"]
-    topic.description = t["description"]
-    topic.created_at = t["created_at"]
+    topic.title = t['title']
+    topic.description = t['description']
+    topic.created_at = t['created_at']
     File.open(File.join(@thumbnails, "#{thumbnail}.jpg")) do |f|
       topic.photo = f
     end
     topic.save
 
     # Add the playlists for this topic.
-    t["playlists"].each { |p| load_playlist! p, topic }
+    t['playlists'].each { |p| load_playlist! p, topic }
   end
 
   # This method will load into the database the contents for a playlist
   # +p+ and associate it as a playlist part of the Topic object +topic+.
   def load_playlist! p, topic
     # Thumbnail is taken from the first episode of the playlist
-    thumbnail = p["videos"][0]["youtube_id"]
+    thumbnail = p['videos'][0]['youtube_id']
 
     # Create the playlist
     playlist = Playlist.new
-    playlist.title = p["title"]
-    playlist.description = p["description"]
-    playlist.created_at = p["created_at"]
-    playlist.youtube_id = p["youtube_id"]
+    playlist.title = p['title']
+    playlist.description = p['description']
+    playlist.created_at = p['created_at']
+    playlist.youtube_id = p['youtube_id']
     playlist.topic = topic
     File.open(File.join(@thumbnails, "#{thumbnail}.jpg")) do |f|
       playlist.photo = f
@@ -81,19 +81,19 @@ class Makigas::DataMigrator
     playlist.save
 
     # Add the videos for this playlist
-    p["videos"].each { |v| load_video! v, playlist }
+    p['videos'].each { |v| load_video! v, playlist }
   end
 
   # This method will load into the database the contents for a video +v+
   # and associate it as a video part of the Playlist object +playlist+.
   def load_video! v, playlist
     video = Video.new
-    video.title = v["title"]
-    video.description = v["description"].split('\n')[0]
-    video.youtube_id = v["youtube_id"]
-    video.natural_duration = v["natural_duration"]
-    video.position = v["position"]
-    video.created_at = v["created_at"]
+    video.title = v['title']
+    video.description = v['description'].split('\n')[0]
+    video.youtube_id = v['youtube_id']
+    video.natural_duration = v['natural_duration']
+    video.position = v['position']
+    video.created_at = v['created_at']
     video.playlist = playlist
     File.open(File.join(@thumbnails, "#{v['youtube_id']}.jpg")) do |f|
       video.thumbnail = f

--- a/lib/makigas/topic_import.rb
+++ b/lib/makigas/topic_import.rb
@@ -2,7 +2,7 @@ import 'yaml'
 
 class Makigas::TopicImport
 
-  def initialize schema
+  def initialize(schema)
     @schema = YAML.load(File.read(schema))
     @schema.each do |topic|
       Topic.create!(title: topic['title'], description: topic['description'], color: topic['color'])

--- a/lib/makigas/topic_import.rb
+++ b/lib/makigas/topic_import.rb
@@ -5,7 +5,7 @@ class Makigas::TopicImport
   def initialize schema
     @schema = YAML.load(File.read(schema))
     @schema.each do |topic|
-      Topic.create!(title: topic["title"], description: topic["description"], color: topic["color"])
+      Topic.create!(title: topic['title'], description: topic['description'], color: topic['color'])
     end
   end
 

--- a/lib/makigas/video_import.rb
+++ b/lib/makigas/video_import.rb
@@ -5,14 +5,14 @@ class Makigas::VideoImport
   def initialize schema
     @schema = YAML.load(File.read(schema))
     @schema.map do |playlist|
-      pl = Playlist.create!(title: playlist["title"],
-        description: playlist["description"], slug: playlist["slug"],
-        youtube_id: playlist["youtube_id"])
+      pl = Playlist.create!(title: playlist['title'],
+        description: playlist['description'], slug: playlist['slug'],
+        youtube_id: playlist['youtube_id'])
       playlist['videos'].each do |video|
-        Video.create!(playlist: pl, title: video["title"],
-          description: video["description"], slug: video["slug"],
-          youtube_id: video["youtube_id"], duration: video["duration"],
-          position: video["position"], created_at: Time.parse(video["created_at"]))
+        Video.create!(playlist: pl, title: video['title'],
+          description: video['description'], slug: video['slug'],
+          youtube_id: video['youtube_id'], duration: video['duration'],
+          position: video['position'], created_at: Time.parse(video['created_at']))
       end
     end
   end

--- a/lib/makigas/video_import.rb
+++ b/lib/makigas/video_import.rb
@@ -2,7 +2,7 @@ import 'yaml'
 
 class Makigas::VideoImport
 
-  def initialize schema
+  def initialize(schema)
     @schema = YAML.load(File.read(schema))
     @schema.map do |playlist|
       pl = Playlist.create!(title: playlist['title'],

--- a/spec/factories/opinions.rb
+++ b/spec/factories/opinions.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     from { 'Programación & Co.' }
     message { 'Estamos encantados con el trabajo que hace este chico.' }
     url { 'https://www.example.com' }
-    photo { fixture_file_upload(Rails.root.join('spec/fixtures/opinion.png'), 'image/png') }
+    photo { Rack::Test::UploadedFile.new('spec/fixtures/opinion.png', 'image/png') }
   end
 end

--- a/spec/factories/playlists.rb
+++ b/spec/factories/playlists.rb
@@ -1,12 +1,10 @@
-include ActionDispatch::TestProcess
-
 FactoryBot.define do
   factory :playlist do
     title { 'Popular music videos' }
     description { 'This list contains a lot of musical videos' }
     youtube_id { 'PLFgquLnL59alCl_2TQvOiD5Vgm1hCaGSI' }
-    thumbnail { fixture_file_upload(Rails.root.join('spec/fixtures/playlist.png'), 'image/png') }
-    card { fixture_file_upload(Rails.root.join('spec/fixtures/card.jpg'), 'image/jpeg') }
+    thumbnail { Rack::Test::UploadedFile.new('spec/fixtures/playlist.png', 'image/png') }
+    card { Rack::Test::UploadedFile.new('spec/fixtures/card.jpg', 'image/jpeg') }
     association :topic, factory: :topic
   end
 end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :topic do
     title { 'Popular musics' }
     description { 'Popular musics of all kinds of styles and genres' }
-    thumbnail { fixture_file_upload(Rails.root.join('spec/fixtures/topic.png'), 'image/png') }
+    thumbnail { Rack::Test::UploadedFile.new('spec/fixtures/topic.png', 'image/png') }
     color { '#55ff55' }
   end
 end

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
-RSpec.feature "Dashboard", type: :feature do
-  before { Capybara.default_host = "http://dashboard.example.com" }
-  after { Capybara.default_host = "http://www.example.com" }
+RSpec.feature 'Dashboard', type: :feature do
+  before { Capybara.default_host = 'http://dashboard.example.com' }
+  after { Capybara.default_host = 'http://www.example.com' }
 
-  context "when not logged in" do
-    it "should not be success" do
+  context 'when not logged in' do
+    it 'should not be success' do
       visit dashboard_path
       expect(page).to have_no_current_path dashboard_topics_path
     end
   end
 
-  context "when logged in" do
-    it "should be success" do
+  context 'when logged in' do
+    it 'should be success' do
       visit dashboard_path
       expect(page.status_code).to eq 200
     end

--- a/spec/features/dashboard/opinions_spec.rb
+++ b/spec/features/dashboard/opinions_spec.rb
@@ -1,82 +1,82 @@
 require 'rails_helper'
 
-RSpec.feature "Dashboard opinions", type: :feature do
-  before { Capybara.default_host = "http://dashboard.example.com" }
-  after { Capybara.default_host = "http://www.example.com" }
+RSpec.feature 'Dashboard opinions', type: :feature do
+  before { Capybara.default_host = 'http://dashboard.example.com' }
+  after { Capybara.default_host = 'http://www.example.com' }
 
-  context "when not logged in" do
-    it "should not be success" do
+  context 'when not logged in' do
+    it 'should not be success' do
       visit dashboard_opinions_path
       expect(page).to have_no_current_path dashboard_topics_path
     end
   end
 
-  context "when logged in" do
+  context 'when logged in' do
     before(:each) {
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
-    scenario "user can list the opinions" do
+    scenario 'user can list the opinions' do
       @opinion = FactoryBot.create(:opinion)
       visit dashboard_opinions_path
       expect(page).to have_link @opinion.from, href: dashboard_opinion_path(@opinion)
     end
 
-    scenario "user can create opinions" do
+    scenario 'user can create opinions' do
       visit dashboard_opinions_path
-      click_link "Nueva Opinión"
+      click_link 'Nueva Opinión'
 
       expect {
-        fill_in "De", with: "Programming and Co"
-        fill_in "Mensaje", with: "Este es el texto de la opinión"
-        fill_in "URL", with: "https://www.example.com"
-        attach_file "Imagen", Rails.root.join('spec/fixtures/opinion.png')
-        click_button "Crear Opinión"
+        fill_in 'De', with: 'Programming and Co'
+        fill_in 'Mensaje', with: 'Este es el texto de la opinión'
+        fill_in 'URL', with: 'https://www.example.com'
+        attach_file 'Imagen', Rails.root.join('spec/fixtures/opinion.png')
+        click_button 'Crear Opinión'
       }.to change { Opinion.count }.by 1
 
-      expect(page).to have_text "Opinión creada correctamente"
+      expect(page).to have_text 'Opinión creada correctamente'
     end
 
-    scenario "user can edit opinions" do
-      @opinion = FactoryBot.create(:opinion, from: "Programming n Co")
+    scenario 'user can edit opinions' do
+      @opinion = FactoryBot.create(:opinion, from: 'Programming n Co')
 
       visit dashboard_opinions_path
       within(:xpath, "//tr[.//td//a[text() = 'Programming n Co']]") do
-        click_link "Editar"
+        click_link 'Editar'
       end
-      fill_in "De", with: "Programming and Co."
-      click_button "Actualizar Opinión"
+      fill_in 'De', with: 'Programming and Co.'
+      click_button 'Actualizar Opinión'
 
-      expect(page).to have_text "Opinión actualizada correctamente"
+      expect(page).to have_text 'Opinión actualizada correctamente'
       @opinion.reload
       expect(@opinion.from).to eq 'Programming and Co.'
     end
 
-    scenario "user can destroy opinions" do
+    scenario 'user can destroy opinions' do
       @opinion = FactoryBot.create(:opinion)
 
       visit dashboard_opinions_path
       expect {
         within(:xpath, "//tr[.//td//a[text() = '#{@opinion.from}']]") do
-          click_button "Destruir"
+          click_button 'Destruir'
         end
       }.to change { Opinion.count }.by -1
 
-      expect(page).to have_text "Opinión destruida correctamente"
+      expect(page).to have_text 'Opinión destruida correctamente'
     end
 
-    scenario "user cannot create invalid opinion" do
+    scenario 'user cannot create invalid opinion' do
       visit dashboard_opinions_path
-      click_link "Nueva Opinión"
+      click_link 'Nueva Opinión'
       expect {
-        fill_in "De", with: "Programming and Co"
-        fill_in "URL", with: "https://www.example.com"
-        attach_file "Imagen", Rails.root.join('spec/fixtures/opinion.png')
-        click_button "Crear Opinión"
+        fill_in 'De', with: 'Programming and Co'
+        fill_in 'URL', with: 'https://www.example.com'
+        attach_file 'Imagen', Rails.root.join('spec/fixtures/opinion.png')
+        click_button 'Crear Opinión'
       }.not_to change { Topic.count }
 
-      expect(page).not_to have_text "Opinión creada correctamente"
+      expect(page).not_to have_text 'Opinión creada correctamente'
     end
   end
 end

--- a/spec/features/dashboard/opinions_spec.rb
+++ b/spec/features/dashboard/opinions_spec.rb
@@ -12,10 +12,10 @@ RSpec.feature 'Dashboard opinions', type: :feature do
   end
 
   context 'when logged in' do
-    before(:each) {
+    before(:each) do
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
-    }
+    end
 
     scenario 'user can list the opinions' do
       @opinion = FactoryBot.create(:opinion)
@@ -27,13 +27,13 @@ RSpec.feature 'Dashboard opinions', type: :feature do
       visit dashboard_opinions_path
       click_link 'Nueva Opinión'
 
-      expect {
+      expect do
         fill_in 'De', with: 'Programming and Co'
         fill_in 'Mensaje', with: 'Este es el texto de la opinión'
         fill_in 'URL', with: 'https://www.example.com'
         attach_file 'Imagen', Rails.root.join('spec/fixtures/opinion.png')
         click_button 'Crear Opinión'
-      }.to change { Opinion.count }.by 1
+      end.to change { Opinion.count }.by 1
 
       expect(page).to have_text 'Opinión creada correctamente'
     end
@@ -57,11 +57,11 @@ RSpec.feature 'Dashboard opinions', type: :feature do
       @opinion = FactoryBot.create(:opinion)
 
       visit dashboard_opinions_path
-      expect {
+      expect do
         within(:xpath, "//tr[.//td//a[text() = '#{@opinion.from}']]") do
           click_button 'Destruir'
         end
-      }.to change { Opinion.count }.by -1
+      end.to change { Opinion.count }.by -1
 
       expect(page).to have_text 'Opinión destruida correctamente'
     end
@@ -69,12 +69,12 @@ RSpec.feature 'Dashboard opinions', type: :feature do
     scenario 'user cannot create invalid opinion' do
       visit dashboard_opinions_path
       click_link 'Nueva Opinión'
-      expect {
+      expect do
         fill_in 'De', with: 'Programming and Co'
         fill_in 'URL', with: 'https://www.example.com'
         attach_file 'Imagen', Rails.root.join('spec/fixtures/opinion.png')
         click_button 'Crear Opinión'
-      }.not_to change { Topic.count }
+      end.not_to change { Topic.count }
 
       expect(page).not_to have_text 'Opinión creada correctamente'
     end

--- a/spec/features/dashboard/playlist_videos_spec.rb
+++ b/spec/features/dashboard/playlist_videos_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.feature "Dashboard playlist videos", type: :feature do
-  before { Capybara.default_host = "http://dashboard.example.com" }
-  after { Capybara.default_host = "http://www.example.com" }
+RSpec.feature 'Dashboard playlist videos', type: :feature do
+  before { Capybara.default_host = 'http://dashboard.example.com' }
+  after { Capybara.default_host = 'http://www.example.com' }
 
   before(:each) {
     @playlist = FactoryBot.create(:playlist)
@@ -12,29 +12,29 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
     ]
   }
 
-  context "when not logged in" do
-    it "should not be success" do
+  context 'when not logged in' do
+    it 'should not be success' do
       visit videos_dashboard_playlist_path(@playlist)
       expect(page).to have_no_current_path videos_dashboard_playlist_path(@playlist)
     end
   end
 
-  context "when logged in" do
+  context 'when logged in' do
     before(:each) {
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
-    scenario "user can access this page via dashboard video page" do
+    scenario 'user can access this page via dashboard video page' do
       visit dashboard_playlists_path
       click_link @playlist.title
-      within(".dashboard-page") do
-        click_link "Vídeos"
+      within('.dashboard-page') do
+        click_link 'Vídeos'
       end
       expect(page).to have_current_path videos_dashboard_playlist_path(@playlist)
     end
 
-    scenario "user can access this page via video count link" do
+    scenario 'user can access this page via video count link' do
       visit dashboard_playlists_path
       within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do
         click_link @playlist.videos.count.to_s
@@ -42,55 +42,55 @@ RSpec.feature "Dashboard playlist videos", type: :feature do
       expect(page).to have_current_path videos_dashboard_playlist_path(@playlist)
     end
 
-    scenario "this page lists videos in the right order" do
+    scenario 'this page lists videos in the right order' do
       visit videos_dashboard_playlist_path(@playlist)
-      within(".dashboard-page tbody") do
-        expect(page).to have_xpath("//tr[1]/td[2]/a", text: @videos[0].title)
-        expect(page).to have_xpath("//tr[2]/td[2]/a", text: @videos[1].title)
+      within('.dashboard-page tbody') do
+        expect(page).to have_xpath('//tr[1]/td[2]/a', text: @videos[0].title)
+        expect(page).to have_xpath('//tr[2]/td[2]/a', text: @videos[1].title)
       end
     end
 
-    scenario "user can move a video down" do
+    scenario 'user can move a video down' do
       visit videos_dashboard_playlist_path(@playlist)
       within(:xpath, "//tr[.//td//a[text() = '#{@videos[0].title}']]") do
-        click_button "Bajar"
+        click_button 'Bajar'
       end
-      within(".dashboard-page tbody") do
-        expect(page).to have_xpath("//tr[1]/td[2]/a", text: @videos[1].title)
-        expect(page).to have_xpath("//tr[2]/td[2]/a", text: @videos[0].title)
+      within('.dashboard-page tbody') do
+        expect(page).to have_xpath('//tr[1]/td[2]/a', text: @videos[1].title)
+        expect(page).to have_xpath('//tr[2]/td[2]/a', text: @videos[0].title)
       end
     end
 
-    scenario "user can move a video down" do
+    scenario 'user can move a video down' do
       visit videos_dashboard_playlist_path(@playlist)
       within(:xpath, "//tr[.//td//a[text() = '#{@videos[1].title}']]") do
-        click_button "Subir"
+        click_button 'Subir'
       end
-      within(".dashboard-page tbody") do
-        expect(page).to have_xpath("//tr[1]/td[2]/a", text: @videos[1].title)
-        expect(page).to have_xpath("//tr[2]/td[2]/a", text: @videos[0].title)
+      within('.dashboard-page tbody') do
+        expect(page).to have_xpath('//tr[1]/td[2]/a', text: @videos[1].title)
+        expect(page).to have_xpath('//tr[2]/td[2]/a', text: @videos[0].title)
       end
     end
 
-    scenario "moving first video up changes nothing" do
+    scenario 'moving first video up changes nothing' do
       visit videos_dashboard_playlist_path(@playlist)
       within(:xpath, "//tr[.//td//a[text() = '#{@videos[0].title}']]") do
-        click_button "Subir"
+        click_button 'Subir'
       end
-      within(".dashboard-page tbody") do
-        expect(page).to have_xpath("//tr[1]/td[2]/a", text: @videos[0].title)
-        expect(page).to have_xpath("//tr[2]/td[2]/a", text: @videos[1].title)
+      within('.dashboard-page tbody') do
+        expect(page).to have_xpath('//tr[1]/td[2]/a', text: @videos[0].title)
+        expect(page).to have_xpath('//tr[2]/td[2]/a', text: @videos[1].title)
       end
     end
 
-    scenario "moving last video down changes nothing" do
+    scenario 'moving last video down changes nothing' do
       visit videos_dashboard_playlist_path(@playlist)
       within(:xpath, "//tr[.//td//a[text() = '#{@videos[1].title}']]") do
-        click_button "Bajar"
+        click_button 'Bajar'
       end
-      within(".dashboard-page tbody") do
-        expect(page).to have_xpath("//tr[1]/td[2]/a", text: @videos[0].title)
-        expect(page).to have_xpath("//tr[2]/td[2]/a", text: @videos[1].title)
+      within('.dashboard-page tbody') do
+        expect(page).to have_xpath('//tr[1]/td[2]/a', text: @videos[0].title)
+        expect(page).to have_xpath('//tr[2]/td[2]/a', text: @videos[1].title)
       end
     end
   end

--- a/spec/features/dashboard/playlist_videos_spec.rb
+++ b/spec/features/dashboard/playlist_videos_spec.rb
@@ -4,13 +4,13 @@ RSpec.feature 'Dashboard playlist videos', type: :feature do
   before { Capybara.default_host = 'http://dashboard.example.com' }
   after { Capybara.default_host = 'http://www.example.com' }
 
-  before(:each) {
+  before(:each) do
     @playlist = FactoryBot.create(:playlist)
     @videos = [
       FactoryBot.create(:video, playlist: @playlist, title: 'Primero', position: 1, youtube_id: '1'),
       FactoryBot.create(:video, playlist: @playlist, title: 'Segundo', position: 2, youtube_id: '2')
     ]
-  }
+  end
 
   context 'when not logged in' do
     it 'should not be success' do
@@ -20,10 +20,10 @@ RSpec.feature 'Dashboard playlist videos', type: :feature do
   end
 
   context 'when logged in' do
-    before(:each) {
+    before(:each) do
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
-    }
+    end
 
     scenario 'user can access this page via dashboard video page' do
       visit dashboard_playlists_path

--- a/spec/features/dashboard/playlists_spec.rb
+++ b/spec/features/dashboard/playlists_spec.rb
@@ -12,10 +12,10 @@ RSpec.feature 'Dashboard playlists', type: :feature do
   end
 
   context 'when logged in' do
-    before(:each) {
+    before(:each) do
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
-    }
+    end
 
     scenario 'user can list the playlists' do
       @playlist = FactoryBot.create(:playlist)
@@ -31,14 +31,14 @@ RSpec.feature 'Dashboard playlists', type: :feature do
     scenario 'user can create playlists' do
       visit dashboard_playlists_path
       click_link 'Nueva Lista'
-      expect {
+      expect do
         fill_in 'Título', with: 'My Playlist'
         fill_in 'Descripción', with: 'This is a playlist part of my site'
         fill_in 'ID de YouTube', with: 'AABBCCDDEEFF'
         attach_file 'Miniatura', Rails.root.join('spec/fixtures/playlist.png')
         attach_file 'Tarjeta', Rails.root.join('spec/fixtures/card.jpg')
         click_button 'Crear Lista de reproducción'
-      }.to change { Playlist.count }.by 1
+      end.to change { Playlist.count }.by 1
       expect(page).to have_text 'Lista creada correctamente'
     end
 
@@ -79,11 +79,11 @@ RSpec.feature 'Dashboard playlists', type: :feature do
       @playlist = FactoryBot.create(:playlist)
 
       visit dashboard_playlists_path
-      expect {
+      expect do
         within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do
           click_button 'Destruir'
         end
-      }.to change { Playlist.count }.by -1
+      end.to change { Playlist.count }.by -1
 
       expect(page).to have_text 'Lista eliminada correctamente'
     end

--- a/spec/features/dashboard/playlists_spec.rb
+++ b/spec/features/dashboard/playlists_spec.rb
@@ -1,91 +1,91 @@
 require 'rails_helper'
 
-RSpec.feature "Dashboard playlists", type: :feature do
-  before { Capybara.default_host = "http://dashboard.example.com" }
-  after { Capybara.default_host = "http://www.example.com" }
+RSpec.feature 'Dashboard playlists', type: :feature do
+  before { Capybara.default_host = 'http://dashboard.example.com' }
+  after { Capybara.default_host = 'http://www.example.com' }
 
-  context "when not logged in" do
-    it "should not be success" do
+  context 'when not logged in' do
+    it 'should not be success' do
       visit dashboard_playlists_path
       expect(page).to have_no_current_path dashboard_playlists_path
     end
   end
 
-  context "when logged in" do
+  context 'when logged in' do
     before(:each) {
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
-    scenario "user can list the playlists" do
+    scenario 'user can list the playlists' do
       @playlist = FactoryBot.create(:playlist)
       @video = FactoryBot.create(:video, playlist: @playlist)
 
       visit dashboard_playlists_path
       expect(page).to have_link @playlist.title, href: dashboard_playlist_path(@playlist)
       within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do
-        expect(page).to have_xpath "//td", text: @playlist.videos.count
+        expect(page).to have_xpath '//td', text: @playlist.videos.count
       end
     end
 
-    scenario "user can create playlists" do
+    scenario 'user can create playlists' do
       visit dashboard_playlists_path
-      click_link "Nueva Lista"
+      click_link 'Nueva Lista'
       expect {
-        fill_in "Título", with: "My Playlist"
-        fill_in "Descripción", with: "This is a playlist part of my site"
-        fill_in "ID de YouTube", with: "AABBCCDDEEFF"
-        attach_file "Miniatura", Rails.root.join('spec/fixtures/playlist.png')
-        attach_file "Tarjeta", Rails.root.join('spec/fixtures/card.jpg')
-        click_button "Crear Lista de reproducción"
+        fill_in 'Título', with: 'My Playlist'
+        fill_in 'Descripción', with: 'This is a playlist part of my site'
+        fill_in 'ID de YouTube', with: 'AABBCCDDEEFF'
+        attach_file 'Miniatura', Rails.root.join('spec/fixtures/playlist.png')
+        attach_file 'Tarjeta', Rails.root.join('spec/fixtures/card.jpg')
+        click_button 'Crear Lista de reproducción'
       }.to change { Playlist.count }.by 1
-      expect(page).to have_text "Lista creada correctamente"
+      expect(page).to have_text 'Lista creada correctamente'
     end
 
-    scenario "user can attach a playlist to a topic" do
+    scenario 'user can attach a playlist to a topic' do
       @topic = FactoryBot.create(:topic)
 
       visit dashboard_playlists_path
-      click_link "Nueva Lista"
-      fill_in "Título", with: "My Playlist"
-      fill_in "Descripción", with: "This is a playlist part of my site"
-      fill_in "ID de YouTube", with: "AABBCCDDEEFF"
-      attach_file "Miniatura", Rails.root.join('spec/fixtures/playlist.png')
-      attach_file "Tarjeta", Rails.root.join('spec/fixtures/card.jpg')
-      select @topic.title, from: "Tema"
-      click_button "Crear Lista de reproducción"
+      click_link 'Nueva Lista'
+      fill_in 'Título', with: 'My Playlist'
+      fill_in 'Descripción', with: 'This is a playlist part of my site'
+      fill_in 'ID de YouTube', with: 'AABBCCDDEEFF'
+      attach_file 'Miniatura', Rails.root.join('spec/fixtures/playlist.png')
+      attach_file 'Tarjeta', Rails.root.join('spec/fixtures/card.jpg')
+      select @topic.title, from: 'Tema'
+      click_button 'Crear Lista de reproducción'
 
-      expect(page).to have_text "Lista creada correctamente"
+      expect(page).to have_text 'Lista creada correctamente'
       expect(@topic.playlists.count).to eq 1
     end
 
-    scenario "user can edit a playlist" do
+    scenario 'user can edit a playlist' do
       @playlist = FactoryBot.create(:playlist, title: 'My old title')
 
       visit dashboard_playlists_path
       within(:xpath, "//tr[.//td//a[text() = 'My old title']]") do
-        click_link "Editar"
+        click_link 'Editar'
       end
 
       fill_in 'Título', with: 'My new title'
       click_button 'Actualizar Lista de reproducción'
 
-      expect(page).to have_text "Lista actualizada correctamente"
+      expect(page).to have_text 'Lista actualizada correctamente'
       @playlist.reload
       expect(@playlist.title).to eq 'My new title'
     end
 
-    scenario "user can destroy a playlist" do
+    scenario 'user can destroy a playlist' do
       @playlist = FactoryBot.create(:playlist)
 
       visit dashboard_playlists_path
       expect {
         within(:xpath, "//tr[.//td//a[text() = '#{@playlist.title}']]") do
-          click_button "Destruir"
+          click_button 'Destruir'
         end
       }.to change { Playlist.count }.by -1
 
-      expect(page).to have_text "Lista eliminada correctamente"
+      expect(page).to have_text 'Lista eliminada correctamente'
     end
   end
 end

--- a/spec/features/dashboard/topics_spec.rb
+++ b/spec/features/dashboard/topics_spec.rb
@@ -12,10 +12,10 @@ RSpec.feature 'Dashboard topics', type: :feature do
   end
 
   context 'when logged in' do
-    before(:each) {
+    before(:each) do
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
-    }
+    end
 
     scenario 'user can list the topics' do
       @topic = FactoryBot.create(:topic)
@@ -32,13 +32,13 @@ RSpec.feature 'Dashboard topics', type: :feature do
       visit dashboard_topics_path
       click_link 'Nuevo Tema'
 
-      expect {
+      expect do
         fill_in 'Título', with: 'My Topic'
         fill_in 'Descripción', with: 'This is a featured topic for the website'
         fill_in 'Color', with: '#ff0000'
         attach_file 'Miniatura', Rails.root.join('spec/fixtures/topic.png')
         click_button 'Crear Tema'
-      }.to change { Topic.count }.by 1
+      end.to change { Topic.count }.by 1
 
       expect(page).to have_text 'Tema creado correctamente'
     end
@@ -63,11 +63,11 @@ RSpec.feature 'Dashboard topics', type: :feature do
       @playlist = FactoryBot.create(:playlist, topic: @topic)
 
       visit dashboard_topics_path
-      expect {
+      expect do
         within(:xpath, "//tr[.//td//a[text() = '#{@topic.title}']]") do
           click_button 'Destruir'
         end
-      }.to change { Topic.count }.by -1
+      end.to change { Topic.count }.by -1
 
       expect(page).to have_text 'Tema eliminado correctamente'
     end
@@ -75,12 +75,12 @@ RSpec.feature 'Dashboard topics', type: :feature do
     scenario 'user cannot create invalid topics' do
       visit dashboard_topics_path
       click_link 'Nuevo Tema'
-      expect {
+      expect do
         fill_in 'Descripción', with: 'This is a featured topic for the website'
         fill_in 'Color', with: '#ff0000'
         attach_file 'Miniatura', Rails.root.join('spec/fixtures/topic.png')
         click_button 'Crear Tema'
-      }.not_to change { Topic.count }
+      end.not_to change { Topic.count }
 
       expect(page).not_to have_text 'Tema creado correctamente'
     end

--- a/spec/features/dashboard/topics_spec.rb
+++ b/spec/features/dashboard/topics_spec.rb
@@ -1,88 +1,88 @@
 require 'rails_helper'
 
-RSpec.feature "Dashboard topics", type: :feature do
-  before { Capybara.default_host = "http://dashboard.example.com" }
-  after { Capybara.default_host = "http://www.example.com" }
+RSpec.feature 'Dashboard topics', type: :feature do
+  before { Capybara.default_host = 'http://dashboard.example.com' }
+  after { Capybara.default_host = 'http://www.example.com' }
 
-  context "when not logged in" do
-    it "should not be success" do
+  context 'when not logged in' do
+    it 'should not be success' do
       visit dashboard_topics_path
       expect(page).to have_no_current_path dashboard_topics_path
     end
   end
 
-  context "when logged in" do
+  context 'when logged in' do
     before(:each) {
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
-    scenario "user can list the topics" do
+    scenario 'user can list the topics' do
       @topic = FactoryBot.create(:topic)
       @playlist = FactoryBot.create(:playlist, topic: @topic)
 
       visit dashboard_topics_path
       expect(page).to have_link @topic.title, href: dashboard_topic_path(@topic)
       within(:xpath, "//tr[.//td//a[text() = '#{@topic.title}']]") do
-        expect(page).to have_xpath "//td", text: @topic.playlists.count
+        expect(page).to have_xpath '//td', text: @topic.playlists.count
       end
     end
 
-    scenario "user can create topics" do
+    scenario 'user can create topics' do
       visit dashboard_topics_path
-      click_link "Nuevo Tema"
+      click_link 'Nuevo Tema'
 
       expect {
-        fill_in "Título", with: "My Topic"
-        fill_in "Descripción", with: "This is a featured topic for the website"
-        fill_in "Color", with: "#ff0000"
-        attach_file "Miniatura", Rails.root.join('spec/fixtures/topic.png')
-        click_button "Crear Tema"
+        fill_in 'Título', with: 'My Topic'
+        fill_in 'Descripción', with: 'This is a featured topic for the website'
+        fill_in 'Color', with: '#ff0000'
+        attach_file 'Miniatura', Rails.root.join('spec/fixtures/topic.png')
+        click_button 'Crear Tema'
       }.to change { Topic.count }.by 1
 
-      expect(page).to have_text "Tema creado correctamente"
+      expect(page).to have_text 'Tema creado correctamente'
     end
 
-    scenario "user can edit topics" do
-      @topic = FactoryBot.create(:topic, title: "My old title")
+    scenario 'user can edit topics' do
+      @topic = FactoryBot.create(:topic, title: 'My old title')
 
       visit dashboard_topics_path
       within(:xpath, "//tr[.//td//a[text() = 'My old title']]") do
-        click_link "Editar"
+        click_link 'Editar'
       end
-      fill_in "Título", with: "My new title"
-      click_button "Actualizar Tema"
+      fill_in 'Título', with: 'My new title'
+      click_button 'Actualizar Tema'
 
-      expect(page).to have_text "Tema actualizado correctamente"
+      expect(page).to have_text 'Tema actualizado correctamente'
       @topic.reload
       expect(@topic.title).to eq 'My new title'
     end
 
-    scenario "user can destroy topics" do
+    scenario 'user can destroy topics' do
       @topic = FactoryBot.create(:topic)
       @playlist = FactoryBot.create(:playlist, topic: @topic)
 
       visit dashboard_topics_path
       expect {
         within(:xpath, "//tr[.//td//a[text() = '#{@topic.title}']]") do
-          click_button "Destruir"
+          click_button 'Destruir'
         end
       }.to change { Topic.count }.by -1
 
-      expect(page).to have_text "Tema eliminado correctamente"
+      expect(page).to have_text 'Tema eliminado correctamente'
     end
 
-    scenario "user cannot create invalid topics" do
+    scenario 'user cannot create invalid topics' do
       visit dashboard_topics_path
-      click_link "Nuevo Tema"
+      click_link 'Nuevo Tema'
       expect {
-        fill_in "Descripción", with: "This is a featured topic for the website"
-        fill_in "Color", with: "#ff0000"
-        attach_file "Miniatura", Rails.root.join('spec/fixtures/topic.png')
-        click_button "Crear Tema"
+        fill_in 'Descripción', with: 'This is a featured topic for the website'
+        fill_in 'Color', with: '#ff0000'
+        attach_file 'Miniatura', Rails.root.join('spec/fixtures/topic.png')
+        click_button 'Crear Tema'
       }.not_to change { Topic.count }
 
-      expect(page).not_to have_text "Tema creado correctamente"
+      expect(page).not_to have_text 'Tema creado correctamente'
     end
   end
 end

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -19,10 +19,10 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
   end
 
   context 'when logged in' do
-    before(:each) {
+    before(:each) do
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
-    }
+    end
 
     scenario 'user can list videos' do
       @video = FactoryBot.create(:video)
@@ -34,7 +34,7 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
       @playlist = FactoryBot.create(:playlist)
 
       visit dashboard_videos_path
-      expect {
+      expect do
         click_link 'Nuevo Vídeo'
         fill_in 'Título', with: 'My video title'
         fill_in 'Descripción', with: 'This is my newest and coolest video'
@@ -43,7 +43,7 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
         fill_in 'duration_seconds', with: '32'
         select @playlist.title, from: 'Lista de reproducción'
         click_button 'Crear Vídeo'
-      }.to change { Video.count }.by 1
+      end.to change { Video.count }.by 1
 
       expect(page).to have_text 'Vídeo creado correctamente'
       expect(@playlist.videos.count).to eq 1
@@ -71,7 +71,7 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
       @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
 
-      expect {
+      expect do
         click_link 'Nuevo Vídeo'
         fill_in 'Título', with: 'My video title'
         fill_in 'Descripción', with: 'This is my newest and coolest video'
@@ -81,7 +81,7 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
         select @playlist.title, from: 'Lista de reproducción'
         check 'video_unfeatured'
         click_button 'Crear Vídeo'
-      }.to change { Video.count }.by 1
+      end.to change { Video.count }.by 1
 
       # Test the video does not appear
       Capybara.app_host = 'http://www.lvh.me:9080'
@@ -94,19 +94,19 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
     scenario 'user cannot create videos with invalid data' do
       @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
-      expect {
+      expect do
         click_link 'Nuevo Vídeo'
         fill_in 'Descripción', with: 'This is my newest and coolest video'
         fill_in 'ID de YouTube', with: 'dQw4w9WgXcQ'
         select @playlist.title, from: 'Lista de reproducción'
         click_button 'Crear Vídeo'
-      }.not_to change { Video.count }
+      end.not_to change { Video.count }
       expect(page).not_to have_text 'Vídeo creado correctamente'
     end
 
     scenario 'user cannot create videos without setting a playlist' do
       visit dashboard_videos_path
-      expect {
+      expect do
         click_link 'Nuevo Vídeo'
         fill_in 'Título', with: 'My video title'
         fill_in 'Descripción', with: 'This is my newest and coolest video'
@@ -114,7 +114,7 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
         fill_in 'duration_minutes', with: '3'
         fill_in 'duration_seconds', with: '32'
         click_button 'Crear Vídeo'
-      }.not_to change { Video.count }
+      end.not_to change { Video.count }
       expect(page).not_to have_text 'Vídeo creado correctamente'
     end
 
@@ -135,11 +135,11 @@ RSpec.feature 'Dashboard videos', type: :feature, js: true do
       @video = FactoryBot.create(:video, title: 'My cool video')
 
       visit dashboard_videos_path
-      expect {
+      expect do
         within(:xpath, "//tr[.//a[text() = '#{@video.title}']]") do
           click_button 'Destruir'
         end
-      }.to change { Video.count }.by -1
+      end.to change { Video.count }.by -1
 
       expect(page).to have_text 'Vídeo destruido correctamente'
       expect(page).not_to have_link 'My cool video'

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Dashboard videos", type: :feature, js: true do
+RSpec.feature 'Dashboard videos', type: :feature, js: true do
   before do
     Capybara.app_host = 'http://dashboard.lvh.me:9080'
     Capybara.server_port = 9080
@@ -11,26 +11,26 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
     Capybara.server_port = nil
   end
 
-  context "when not logged in" do
-    it "should not be success" do
+  context 'when not logged in' do
+    it 'should not be success' do
       visit dashboard_videos_path
       expect(page).to have_no_current_path dashboard_playlists_path
     end
   end
 
-  context "when logged in" do
+  context 'when logged in' do
     before(:each) {
       @user = FactoryBot.create(:user)
       login_as @user, scope: :user
     }
 
-    scenario "user can list videos" do
+    scenario 'user can list videos' do
       @video = FactoryBot.create(:video)
       visit dashboard_videos_path
       expect(page).to have_link @video.title
     end
 
-    scenario "user can create videos" do
+    scenario 'user can create videos' do
       @playlist = FactoryBot.create(:playlist)
 
       visit dashboard_videos_path
@@ -49,7 +49,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
       expect(@playlist.videos.count).to eq 1
     end
 
-    scenario "user can set the duration of a video" do
+    scenario 'user can set the duration of a video' do
       @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
 
@@ -67,7 +67,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
       expect(page).to have_text '1:05:40'
     end
 
-    scenario "user can create unfeatured videos" do
+    scenario 'user can create unfeatured videos' do
       @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
 
@@ -84,14 +84,14 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
       }.to change { Video.count }.by 1
 
       # Test the video does not appear
-      Capybara.app_host = "http://www.lvh.me:9080"
+      Capybara.app_host = 'http://www.lvh.me:9080'
       visit root_path
       within '.recent-videos' do
         expect(page).not_to have_link 'My video title'
       end
     end
 
-    scenario "user cannot create videos with invalid data" do
+    scenario 'user cannot create videos with invalid data' do
       @playlist = FactoryBot.create(:playlist)
       visit dashboard_videos_path
       expect {
@@ -104,7 +104,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
       expect(page).not_to have_text 'Vídeo creado correctamente'
     end
 
-    scenario "user cannot create videos without setting a playlist" do
+    scenario 'user cannot create videos without setting a playlist' do
       visit dashboard_videos_path
       expect {
         click_link 'Nuevo Vídeo'
@@ -118,7 +118,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
       expect(page).not_to have_text 'Vídeo creado correctamente'
     end
 
-    scenario "user can edit videos" do
+    scenario 'user can edit videos' do
       @video = FactoryBot.create(:video, title: 'My old video')
 
       visit dashboard_videos_path
@@ -131,7 +131,7 @@ RSpec.feature "Dashboard videos", type: :feature, js: true do
       expect(page).to have_text 'Vídeo actualizado correctamente'
     end
 
-    scenario "user can destroy videos" do
+    scenario 'user can destroy videos' do
       @video = FactoryBot.create(:video, title: 'My cool video')
 
       visit dashboard_videos_path

--- a/spec/features/front/front_page_spec.rb
+++ b/spec/features/front/front_page_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
-RSpec.feature "Front page", type: :feature do
-  scenario "loads successfully" do
+RSpec.feature 'Front page', type: :feature do
+  scenario 'loads successfully' do
     visit root_path
     expect(page.status_code).to be 200
   end
 
-  scenario "presents the project" do
+  scenario 'presents the project' do
     visit root_path
-    expect(page).to have_text "¿Qué es makigas?"
+    expect(page).to have_text '¿Qué es makigas?'
   end
 
-  scenario "allows the user to navigate for topics" do
+  scenario 'allows the user to navigate for topics' do
     visit root_path
     click_link 'Explora las temáticas'
     expect(page).to have_current_path topics_path

--- a/spec/features/front/front_videos_spec.rb
+++ b/spec/features/front/front_videos_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Videos listed in front page", type: :feature do
+RSpec.feature 'Videos listed in front page', type: :feature do
   let!(:video) { FactoryBot.create(:video) }
 
   scenario 'displays thumbnail' do
@@ -10,7 +10,7 @@ RSpec.feature "Videos listed in front page", type: :feature do
       end
   end
 
-  scenario "links to the video" do
+  scenario 'links to the video' do
     visit root_path
     within '.recent-videos' do
       expect(page).to have_link video.title, href: playlist_video_path(video, playlist_id: video.playlist)

--- a/spec/features/playlists/playlist_page_spec.rb
+++ b/spec/features/playlists/playlist_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Playlist page", type: :feature do
+RSpec.feature 'Playlist page', type: :feature do
   before { @playlist = FactoryBot.create(:playlist) }
 
   scenario 'displays playlist information' do

--- a/spec/features/playlists/playlists_page_spec.rb
+++ b/spec/features/playlists/playlists_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Playlists page", type: :feature do
+RSpec.feature 'Playlists page', type: :feature do
   before { @playlist = FactoryBot.create(:playlist) }
 
   scenario 'displays information about playlists' do

--- a/spec/features/topics/topic_page_spec.rb
+++ b/spec/features/topics/topic_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Topic page", type: :feature do
+RSpec.feature 'Topic page', type: :feature do
   before { @topic = FactoryBot.create(:topic) }
 
   scenario 'shows information about a topic' do

--- a/spec/features/topics/topics_page_spec.rb
+++ b/spec/features/topics/topics_page_spec.rb
@@ -9,9 +9,9 @@ RSpec.feature 'Topics page', type: :feature do
   end
 
   context 'when there are topics' do
-    before(:each) {
+    before(:each) do
       @topic = FactoryBot.create(:topic)
-    }
+    end
 
     it 'it is success' do
       visit topics_path

--- a/spec/features/topics/topics_page_spec.rb
+++ b/spec/features/topics/topics_page_spec.rb
@@ -1,39 +1,39 @@
 require 'rails_helper'
 
-RSpec.feature "Topics page", type: :feature do
-  context "when there are no topics" do
-    it "should be success" do
+RSpec.feature 'Topics page', type: :feature do
+  context 'when there are no topics' do
+    it 'should be success' do
       visit topics_path
       expect(page.status_code).to be 200
     end
   end
 
-  context "when there are topics" do
+  context 'when there are topics' do
     before(:each) {
       @topic = FactoryBot.create(:topic)
     }
 
-    it "it is success" do
+    it 'it is success' do
       visit topics_path
       expect(page.status_code).to be 200
     end
 
-    it "shows the topics" do
+    it 'shows the topics' do
       visit topics_path
       expect(page).to have_text @topic.title
     end
 
-    it "describes the topics" do
+    it 'describes the topics' do
       visit topics_path
       expect(page).to have_text @topic.description
     end
 
-    it "shows the topic photo" do
+    it 'shows the topic photo' do
       visit topics_path
       expect(page).to have_css "img[src*='#{@topic.thumbnail.url(:small)}']"
     end
 
-    it "links to a topic" do
+    it 'links to a topic' do
       visit topics_path
       expect(page).to have_link @topic.title, href: topic_path(@topic)
     end

--- a/spec/features/videos/video_page_spec.rb
+++ b/spec/features/videos/video_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Video page", type: :feature do
+RSpec.feature 'Video page', type: :feature do
   before { @video = FactoryBot.create(:video, duration: 133) }
 
   scenario 'there is information about the video' do

--- a/spec/features/videos/videos_page_spec.rb
+++ b/spec/features/videos/videos_page_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
-RSpec.feature "Topics page", type: :feature do
-  scenario "still loads without videos" do
+RSpec.feature 'Topics page', type: :feature do
+  scenario 'still loads without videos' do
     visit videos_path
     expect(page.status_code).to be 200
   end
 
-  scenario "displays information about videos" do
+  scenario 'displays information about videos' do
     video = FactoryBot.create(:video, duration: 133)
 
     visit videos_path
     expect(page).to have_link video.title, href: playlist_video_path(video, playlist_id: video.playlist)
     expect(page).to have_text video.description
-    expect(page).to have_text "Duración: 2:13"
+    expect(page).to have_text 'Duración: 2:13'
     expect(page).to have_link video.playlist.title, href: playlist_path(video.playlist)
   end
 
-  scenario "displays topic if the playlist has one" do
+  scenario 'displays topic if the playlist has one' do
     topic = FactoryBot.create(:topic)
     playlist = FactoryBot.create(:playlist, topic: topic)
     video = FactoryBot.create(:video, playlist: playlist)
@@ -25,7 +25,7 @@ RSpec.feature "Topics page", type: :feature do
     expect(page).to have_link topic.title, href: topic_path(topic)
   end
 
-  scenario "scheduled videos are not displayed" do
+  scenario 'scheduled videos are not displayed' do
     published = FactoryBot.create(:yesterday_video, youtube_id: 'PUBLISHED', title: 'Published')
     scheduled = FactoryBot.create(:tomorrow_video, youtube_id: 'TOMORROW', title: 'Scheduled')
 

--- a/spec/features/videos/videos_search_spec.rb
+++ b/spec/features/videos/videos_search_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-RSpec.feature "Videos search", type: :feature do
-  context "searching by length" do
+RSpec.feature 'Videos search', type: :feature do
+  context 'searching by length' do
     before(:each) do
       @short = FactoryBot.create(:video, duration: 200, title: 'Short', youtube_id: '1')
       @medium = FactoryBot.create(:video, duration: 600, title: 'Medium', youtube_id: '2')
       @long = FactoryBot.create(:video, duration: 1200, title: 'Long', youtube_id: '3')
     end
 
-    scenario "can search for short length videos" do
+    scenario 'can search for short length videos' do
       visit videos_path
       choose 'Cortos'
       click_button 'Aplicar filtros'
@@ -17,7 +17,7 @@ RSpec.feature "Videos search", type: :feature do
       expect(page).not_to have_link @long.title, href: video_path(@long)
     end
 
-    scenario "can search for medium length videos" do
+    scenario 'can search for medium length videos' do
       visit videos_path
       choose 'Medios'
       click_button 'Aplicar filtros'
@@ -26,7 +26,7 @@ RSpec.feature "Videos search", type: :feature do
       expect(page).not_to have_link @long.title, href: video_path(@long)
     end
 
-    scenario "can search for long length videos" do
+    scenario 'can search for long length videos' do
       visit videos_path
       choose 'Largos'
       click_button 'Aplicar filtros'
@@ -36,7 +36,7 @@ RSpec.feature "Videos search", type: :feature do
     end
   end
 
-  context "searching by topic" do
+  context 'searching by topic' do
     before(:each) do
       @topic1 = FactoryBot.create(:topic, title: 'First Topic')
       @topic2 = FactoryBot.create(:topic, title: 'Second Topic')
@@ -46,7 +46,7 @@ RSpec.feature "Videos search", type: :feature do
       @video2 = FactoryBot.create(:video, title: 'Second', youtube_id: 'B', playlist: @playlist2)
     end
 
-    scenario "can search for videos in a topic" do
+    scenario 'can search for videos in a topic' do
       visit videos_path
 
       check 'First Topic'
@@ -55,7 +55,7 @@ RSpec.feature "Videos search", type: :feature do
       expect(page).not_to have_link @video2.title, href: video_path(@video2)
     end
 
-    scenario "can search for videos in multiple topics" do
+    scenario 'can search for videos in multiple topics' do
       visit videos_path
 
       check 'First Topic'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,78 +3,78 @@ require 'rails_helper'
 RSpec.describe ApplicationHelper, type: :helper do
   context 'running time' do
     it 'should render seconds' do
-      expect(running_time 45).to eq '0:45'
+      expect(running_time(45)).to eq '0:45'
     end
 
     it 'should render a minute' do
-      expect(running_time 60).to eq '1:00'
+      expect(running_time(60)).to eq '1:00'
     end
 
     it 'should render minutes' do
-      expect(running_time 85).to eq '1:25'
+      expect(running_time(85)).to eq '1:25'
     end
 
     it 'should render more than 10 minutes' do
-      expect(running_time 685).to eq '11:25'
+      expect(running_time(685)).to eq '11:25'
     end
 
     it 'should render an hour' do
-      expect(running_time 3600). to eq '1:00:00'
+      expect(running_time(3600)). to eq '1:00:00'
     end
 
     it 'should render hours' do
-      expect(running_time 4625).to eq '1:17:05'
+      expect(running_time(4625)).to eq '1:17:05'
     end
   end
 
   context 'parsing time' do
     it 'should parse H:MM:SS' do
-      expect(extract_time '1:17:05').to eq 4625
+      expect(extract_time('1:17:05')).to eq 4625
     end
 
     it 'should parse HH:MM:SS' do
-      expect(extract_time '01:17:05').to eq 4625
+      expect(extract_time('01:17:05')).to eq 4625
     end
 
     it 'should parse M:SS' do
-      expect(extract_time '1:25').to eq 85
+      expect(extract_time('1:25')).to eq 85
     end
 
     it 'should parse MM:SS' do
-      expect(extract_time '01:25').to eq 85
+      expect(extract_time('01:25')).to eq 85
     end
 
     it 'should parse S' do
-      expect(extract_time '9').to eq 9
+      expect(extract_time('9')).to eq 9
     end
 
     it 'should parse 0S' do
-      expect(extract_time '09').to eq 9
+      expect(extract_time('09')).to eq 9
     end
 
     it 'should parse SS' do
-      expect(extract_time '45').to eq 45
+      expect(extract_time('45')).to eq 45
     end
 
     it 'should allow non start by zero' do
-      expect(extract_time '1:17:05').to eq 4625
-      expect(extract_time '1:25').to eq 85
+      expect(extract_time('1:17:05')).to eq 4625
+      expect(extract_time('1:25')).to eq 85
     end
 
     it 'should not allow non start by zero inside' do
-      expect(extract_time '1:2:01').to eq nil
-      expect(extract_time '1:02:1').to eq nil
-      expect(extract_time '1:2').to eq nil
+      expect(extract_time('1:2:01')).to eq nil
+      expect(extract_time('1:02:1')).to eq nil
+      expect(extract_time('1:2')).to eq nil
     end
 
     it 'should not allow invalid minutes' do
-      expect(extract_time '78:59').to eq nil
-      expect(extract_time '2:78:59').to eq nil
+      expect(extract_time('78:59')).to eq nil
+      expect(extract_time('2:78:59')).to eq nil
     end
 
     it 'should not allow invalid seconds' do
-      expect(extract_time '1:81').to eq nil
-      expect(extract_time '2:01:81').to eq nil
+      expect(extract_time('1:81')).to eq nil
+      expect(extract_time('2:01:81')).to eq nil
     end
   end
 end

--- a/spec/helpers/dashboard/videos_helper_spec.rb
+++ b/spec/helpers/dashboard/videos_helper_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe Dashboard::VideosHelper, type: :helper do
   before(:each) { @video = FactoryBot.create(:video) }
 
   context 'dashboard_video' do
-    it { expect(dashboard_video_path @video).to eq dashboard_playlist_video_path(@video, playlist_id: @video.playlist) }
-    it { expect(dashboard_video_url @video).to eq dashboard_playlist_video_url(@video, playlist_id: @video.playlist) }
+    it { expect(dashboard_video_path(@video)).to eq dashboard_playlist_video_path(@video, playlist_id: @video.playlist) }
+    it { expect(dashboard_video_url(@video)).to eq dashboard_playlist_video_url(@video, playlist_id: @video.playlist) }
   end
 
   context 'move_dashboard_video' do
-    it { expect(move_dashboard_video_path @video).to eq move_dashboard_playlist_video_path(@video, playlist_id: @video.playlist) }
-    it { expect(move_dashboard_video_url @video).to eq move_dashboard_playlist_video_url(@video, playlist_id: @video.playlist) }
+    it { expect(move_dashboard_video_path(@video)).to eq move_dashboard_playlist_video_path(@video, playlist_id: @video.playlist) }
+    it { expect(move_dashboard_video_url(@video)).to eq move_dashboard_playlist_video_url(@video, playlist_id: @video.playlist) }
   end
 
   context 'edit_dashboard_video' do
-    it { expect(edit_dashboard_video_path @video).to eq edit_dashboard_playlist_video_path(@video, playlist_id: @video.playlist) }
-    it { expect(edit_dashboard_video_url @video).to eq edit_dashboard_playlist_video_url(@video, playlist_id: @video.playlist) }
+    it { expect(edit_dashboard_video_path(@video)).to eq edit_dashboard_playlist_video_path(@video, playlist_id: @video.playlist) }
+    it { expect(edit_dashboard_video_url(@video)).to eq edit_dashboard_playlist_video_url(@video, playlist_id: @video.playlist) }
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe Video, type: :model do
       video.natural_duration = '1:00:00'
       expect(video.duration).to eq 3600
       video.natural_duration = '9:59:59'
-      expect(video.duration).to eq 35999
+      expect(video.duration).to eq 35_999
       video.natural_duration = '10:00:00'
-      expect(video.duration).to eq 36000
+      expect(video.duration).to eq 36_000
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rspec'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,53 +40,51 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # These two settings work together to allow you to limit a spec run
+  #   # to individual examples or groups you care about by tagging them with
+  #   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  #   # get run.
+  #   config.filter_run :focus
+  #   config.run_all_when_everything_filtered = true
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = 'doc'
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
This pull request fixes almost all the pending cops to be fixed in rubocop_todo.yml that are in the Style/* namescape. Skipped cops so far:

* Style/FrozenStringLiteralComment (it will touch so many files I'd rather do a separate PR for it).