### PR TITLE
fix: replace rails-ujs with @rails/ujs

### DIFF
--- a/app/javascript/packs/vendor.js
+++ b/app/javascript/packs/vendor.js
@@ -1,7 +1,9 @@
 import 'jquery/src/jquery';
 import 'bootstrap';
 import 'cookieconsent';
-import 'rails-ujs';
+import Rails from '@rails/ujs';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'cookieconsent/build/cookieconsent.min.css';
+
+Rails.start()

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
   "license": "GPLv3",
   "private": true,
   "dependencies": {
+    "@rails/ujs": "^6.1.4-1",
     "@rails/webpacker": "5.4.2",
     "bootstrap": "^3.4.0",
     "cookieconsent": "^3.1.0",
-    "jquery": "^3.6.0",
-    "rails-ujs": "^5.2.6"
+    "jquery": "^3.6.0"
+  },
+  "devDependencies": {
+    "@types/rails__ujs": "^6.0.1"
   }
 }

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -113,7 +113,9 @@ RSpec.describe 'Dashboard videos', type: :feature, js: true do
     it 'user can destroy videos' do
       visit dashboard_videos_path
       within(:xpath, "//tr[.//a[text() = '#{video.title}']]") do
-        click_button 'Destruir'
+        page.accept_confirm do
+          click_button 'Destruir'
+        end
       end
 
       aggregate_failures do

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,6 +1069,11 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@rails/ujs@^6.1.4-1":
+  version "6.1.4-1"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.4-1.tgz#37507fe288a1c7c3a593602aa4dea42e5cb5797f"
+  integrity sha512-Fewm2wHk1n6Kf4E86dzzHDJOFg4EWcSHH3FsMEGs59bTdmf7099mjkOssOQtBqju4R39iaAOQNui7r8P+Q5Dgg==
+
 "@rails/webpacker@5.4.2":
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.4.2.tgz#efc94f7ff396529411bb02a9da964e269ff2edb0"
@@ -1132,6 +1137,11 @@
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
+
+"@types/rails__ujs@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/rails__ujs/-/rails__ujs-6.0.1.tgz#83c5aa1dad88ca869de05a9523eff58041ab307a"
+  integrity sha512-CVwNOdzTQ9qn6X6HPwx6ikH1T9ueJTdfjwFlXFhGvzXsQuESUksibfSosgxs1D/Q1kVEpjxeXD2RzqJv0Ma5Gw==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4684,10 +4694,6 @@ querystring-es3@^0.2.0:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-
-rails-ujs@^5.2.6:
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/rails-ujs/-/rails-ujs-5.2.6.tgz#4193242a108d0cd9ed3595695644755c0bd329eb"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
It turns out that Rails 6.0 deprecated rails-ujs with @rails/ujs.
Therefore, events for the Rails unobtrusive JS library are not being
handled anymore, which is noticeable because suddenly I'm able to delete
stuff without getting confirmation prompts before.

This commit will uninstall rails-ujs and replace it with @rails/ujs. A
few tests have been added to assert that confirmation prompts are being
presented in destructive actions.