### PR TITLE
refactor: move video search filters to the model

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -2,10 +2,8 @@
 
 class VideosController < ApplicationController
   def index
-    @videos = Video.includes(:playlist, playlist: :topic).visible.joins(:playlist)
-    @videos = @videos.where(length_query) if params[:length]
-    @videos = @videos.where(playlists: { topic_id: topic_ids }) if params[:topic]
-    @videos = @videos.order(published_at: :desc).page(params[:page]).per 10
+    @videos = Video.visible.free_filter(filter_params).joins(:playlist)
+                   .order(published_at: :desc).page(params[:page]).per(10)
   end
 
   def show
@@ -28,17 +26,7 @@ class VideosController < ApplicationController
 
   private
 
-  LENGTH_QUERIES = {
-    'short' => 'duration <= 300',
-    'medium' => 'duration > 300 and duration <= 900',
-    'long' => 'duration > 900'
-  }.freeze
-
-  def length_query
-    LENGTH_QUERIES[params[:length]]
-  end
-
-  def topic_ids
-    Topic.where(slug: params[:topic]).pluck(:id)
+  def filter_params
+    params.permit(:length, topic: [])
   end
 end


### PR DESCRIPTION
Adding more filters to the videos#index controller action is getting
cumbersome and I am making the linter cry. This commit will fix this
by converting filters to model scopes which can be combined using the
Video.free_filter method.

[ALWAYS link to the tracking issue for your pull request. Don't send pull requests for features that don't have a prior discussion. As much as code contributions are loved, there is a roadmap to follow and new ideas should be notified to the project leaders so that we can allocate it into the roadmap or reject it if it's out of scope.]