### PR TITLE
feat: add tags to videos

### DIFF
--- a/app/controllers/dashboard/videos_controller.rb
+++ b/app/controllers/dashboard/videos_controller.rb
@@ -68,7 +68,9 @@ module Dashboard
 
     def video_params
       params.require(:video).permit(:title, :description, :youtube_id, :duration,
-                                    :playlist_id, :unfeatured, :published_at)
+                                    :tags, :playlist_id, :unfeatured, :published_at).tap do |video_params|
+        video_params[:tags] = video_params[:tags].split if video_params[:tags].present?
+      end
     end
   end
 end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -27,6 +27,6 @@ class VideosController < ApplicationController
   private
 
   def filter_params
-    params.permit(:length, topic: [])
+    params.permit(:length, tag: [], topic: [])
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -17,6 +17,7 @@ class Video < ApplicationRecord
   # Filterable scopes
   scope :filter_by_length, ->(duration) { where(LENGTH_QUERIES[duration]) }
   scope :filter_by_topic, ->(slug) { includes(playlist: :topic).where('topic.slug' => slug) }
+  scope :filter_by_tag, ->(tag) { where('tags @> ARRAY[?]::varchar[]', tag) }
 
   # Validations.
   validates :title, presence: true, length: { maximum: 100 }
@@ -35,6 +36,10 @@ class Video < ApplicationRecord
 
       videos.send(scope, value)
     end
+  end
+
+  def self.tags
+    pluck(Arel.sql('DISTINCT unnest(tags)'))
   end
 
   # Natural duration

--- a/app/views/dashboard/videos/_form.html.erb
+++ b/app/views/dashboard/videos/_form.html.erb
@@ -10,6 +10,7 @@
     <%= number_field_tag nil, ((@video.duration % 60) rescue 0), id: 'duration_seconds', class: 'form-control', min: 0, max: 59 %>
     </p>
   <% end %>
+  <%= form.input :tags %>
   <%= form.association :playlist, include_blank: :translate %>
   <%= form.input :published_at %>
   <%= form.input :unfeatured %>

--- a/app/views/dashboard/videos/show.html.erb
+++ b/app/views/dashboard/videos/show.html.erb
@@ -34,6 +34,10 @@
     <td><%= link_to @video.playlist.title, [:dashboard, @video.playlist] %></td>
   </tr>
   <tr>
+    <td><%= t('.tags') %></td>
+    <td><%= @video.tags.sort.join(' ') %></td>
+  </tr>
+  <tr>
     <td><%= t('.published_at') %></td>
     <td><%= l @video.published_at %></td>
   </tr>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -12,6 +12,7 @@
 
 <title><%= content_for?(:title) ? content_for(:title) : "makigas" %></title>
 <%= tag(:meta, name: 'description', content: content_for(:description)) if content_for?(:description) %>
+<%= tag(:meta, name: 'tags', content: content_for(:tags)) if content_for?(:tags) %>
 <%= tag(:link, rel: 'canonical', href: canonical_url) %>
 <%= tag(:link, rel: 'alternate', href: feed_videos_url, title: t('.videos_feed'), type: 'application/atom+xml') %>
 

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -18,6 +18,12 @@
             <% if v.playlist.topic %>
               &bull; <%= t('.topic_html', topic: link_to(v.playlist.topic.title, v.playlist.topic)) %>
             <% end %>
+	    <% if v.tags.present? %>
+	    &bull; <%= t('.tags') %>:
+	    <% v.tags.each do |tag| %>
+	      <%= link_to tag, videos_path(tag: tag) %>
+	    <% end %>
+	    <% end %>
           </p>
         </div>
       <% end %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "#{@video.position}. #{@video.title} – #{@video.playlist.title} – makigas" %>
 <% content_for :description, @video.description %>
+<% content_for(:tags, @video.tags.sort.join(' ')) if @video.tags.present? %>
 <% content_for :twitter do %>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@makigas">

--- a/config/locales/dashboard.es.yml
+++ b/config/locales/dashboard.es.yml
@@ -275,6 +275,7 @@ es:
           one: "%{count} segundo"
           other: "%{count} segundos"
         title: Título
+        tags: Etiquetas
         thumbnail: Miniatura
         videos: Vídeos
         youtube_id: ID de YouTube

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -137,6 +137,7 @@ es:
       duration: "Duración: %{duration}"
       topic_html: "Tema: %{topic}"
       playlist_html: "Serie: %{playlist}"
+      tags: Etiquetas
       filter:
         by_length: Por duración
         any_length: Cualquier duración

--- a/config/locales/model.es.yml
+++ b/config/locales/model.es.yml
@@ -48,6 +48,7 @@ es:
         position: Posición
         natural_duration: Duración
         slug: URL
+        tags: Etiquetas
         thumbnail: Miniatura
         playlist: Lista de reproducción
         published_at: Fecha de publicación

--- a/db/migrate/20211012135028_add_tag_to_video.rb
+++ b/db/migrate/20211012135028_add_tag_to_video.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTagToVideo < ActiveRecord::Migration[6.1]
+  def change
+    add_column :videos, :tags, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_10_191215) do
+ActiveRecord::Schema.define(version: 2021_10_12_135028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2021_09_10_191215) do
     t.boolean "unfeatured", default: false, null: false
     t.datetime "published_at", null: false
     t.boolean "private", default: false, null: false
+    t.string "tags", default: [], array: true
     t.index ["slug"], name: "index_videos_on_slug"
     t.index ["youtube_id"], name: "index_videos_on_youtube_id", unique: true
   end

--- a/spec/features/dashboard/videos_spec.rb
+++ b/spec/features/dashboard/videos_spec.rb
@@ -43,12 +43,14 @@ RSpec.describe 'Dashboard videos', type: :feature, js: true do
       fill_in 'duration_hours', with: '1'
       fill_in 'duration_minutes', with: '5'
       fill_in 'duration_seconds', with: '40'
+      fill_in 'Etiquetas', with: 'javascript ruby go'
       select playlist.title, from: 'Lista de reproducción'
       click_button 'Crear Vídeo'
 
       aggregate_failures do
         expect(page).to have_text 'Vídeo creado correctamente'
         expect(page).to have_text 'My video title'
+        expect(page).to have_text 'go javascript ruby'
         expect(page).to have_text '1:05:40'
       end
     end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -179,4 +179,20 @@ RSpec.describe Video, type: :model do
       expect(videos).not_to include scheduled
     end
   end
+
+  describe '.tagged_as' do
+    it 'filters by tag' do
+      v1 = create(:video, youtube_id: '11223344', tags: [])
+      v2 = create(:video, youtube_id: '11223355', tags: ['python'])
+      expect(Video.tagged_as('python')).to match [v2]
+    end
+  end
+
+  describe '.tags' do
+    it 'returns all the available tags' do
+      v1 = create(:video, youtube_id: '11223344', tags: %w[python ruby])
+      v2 = create(:video, youtube_id: '11223355', tags: %w[ruby git])
+      expect(Video.tags).to match_array %w[python git ruby]
+    end
+  end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -180,11 +180,17 @@ RSpec.describe Video, type: :model do
     end
   end
 
-  describe '.tagged_as' do
+  describe '.filter_by_tag' do
     it 'filters by tag' do
       create(:video, youtube_id: '11223344', tags: [])
       v2 = create(:video, youtube_id: '11223355', tags: ['python'])
-      expect(described_class.tagged_as('python')).to match [v2]
+      expect(described_class.filter_by_tag('python')).to match [v2]
+    end
+
+    it 'filters by multiple tags' do
+      create(:video, youtube_id: '11223344', tags: ['python'])
+      v2 = create(:video, youtube_id: '11223355', tags: %w[python django])
+      expect(described_class.filter_by_tag(%w[python django])).to match [v2]
     end
   end
 

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -182,17 +182,17 @@ RSpec.describe Video, type: :model do
 
   describe '.tagged_as' do
     it 'filters by tag' do
-      v1 = create(:video, youtube_id: '11223344', tags: [])
+      create(:video, youtube_id: '11223344', tags: [])
       v2 = create(:video, youtube_id: '11223355', tags: ['python'])
-      expect(Video.tagged_as('python')).to match [v2]
+      expect(described_class.tagged_as('python')).to match [v2]
     end
   end
 
   describe '.tags' do
     it 'returns all the available tags' do
-      v1 = create(:video, youtube_id: '11223344', tags: %w[python ruby])
-      v2 = create(:video, youtube_id: '11223355', tags: %w[ruby git])
-      expect(Video.tags).to match_array %w[python git ruby]
+      create(:video, youtube_id: '11223344', tags: %w[python ruby])
+      create(:video, youtube_id: '11223355', tags: %w[ruby git])
+      expect(described_class.tags).to match_array %w[python git ruby]
     end
   end
 end


### PR DESCRIPTION
After running this commit, it will be possible for videos to have
tags. Tags are stored as an array of strings per video. There are
scoped methods for filtering videos with a specific tag, and there are
methods for getting all the possible tags in the system.

[ALWAYS link to the tracking issue for your pull request. Don't send pull requests for features that don't have a prior discussion. As much as code contributions are loved, there is a roadmap to follow and new ideas should be notified to the project leaders so that we can allocate it into the roadmap or reject it if it's out of scope.]