### PR TITLE
feat: show notes

### DIFF
--- a/app/controllers/dashboard/show_notes_controller.rb
+++ b/app/controllers/dashboard/show_notes_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Dashboard
+  class ShowNotesController < Dashboard::DashboardController
+    before_action :set_video
+
+    def show
+      @show_note = ShowNote.find_or_initialize_by(documentable: @video)
+    end
+
+    def create
+      @show_note = ShowNote.find_or_initialize_by(documentable: @video)
+      if @show_note.update(show_note_params)
+        redirect_to [:dashboard, @playlist, @video]
+      else
+        render :show
+      end
+    end
+
+    def update
+      @show_note = ShowNote.find_or_initialize_by(documentable: @video)
+      if @show_note.update(show_note_params)
+        redirect_to [:dashboard, @playlist, @video]
+      else
+        render :show
+      end
+    end
+
+    def destroy
+      @show_note = ShowNote.find_by(documentable: @video)
+      @show_note.destroy if @show_note.present?
+      redirect_to [:dashboard, @playlist, @video]
+    end
+
+    private
+
+    def show_note_params
+      params.require(:show_note).permit(:language, :content)
+    end
+
+    def set_video
+      @playlist = Playlist.friendly.find(params[:playlist_id])
+      @video = @playlist.videos.find_by!(slug: params[:video_id])
+    end
+  end
+end

--- a/app/models/show_note.rb
+++ b/app/models/show_note.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ShowNote < Document
+  after_destroy :index_documentable
+  after_save :index_documentable
+
+  def index_documentable
+    documentable.index! if documentable.respond_to?(:index)
+  end
+end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -7,9 +7,8 @@ class Video < ApplicationRecord
   meilisearch per_environment: true, raise_on_failure: Rails.env.development? do
     attribute :title, :description
 
-    attribute(:transcription) do
-      transcription&.content
-    end
+    attribute(:transcription) { transcription&.content }
+    attribute(:show_note) { show_note&.content }
 
     attribute :slug
 
@@ -49,6 +48,7 @@ class Video < ApplicationRecord
   validates :playlist, presence: true
   validates :published_at, presence: true
 
+  has_one :show_note, dependent: :destroy, as: :documentable
   has_one :transcription, dependent: :destroy, as: :documentable
 
   def self.free_filter(filter_params)

--- a/app/views/dashboard/show_notes/show.html.erb
+++ b/app/views/dashboard/show_notes/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for :header do %>
+  <ol class="breadcrumb">
+    <li><%= link_to t('.dashboard'), :dashboard %></li>
+    <li><%= link_to @playlist.title, [:dashboard, @playlist] %></li>
+    <li><%= link_to @video.title, [:dashboard, @playlist, @video] %></li>
+    <li class="current"><%= t('.show_notes') %></li>
+  </ol>
+  <h1><%= @video.title %></h1>
+<% end %>
+
+<% content_for :toolbar do %>
+  <%= link_to t('.cancel'), [:dashboard, @playlist, @video], class: 'btn btn-default' %>
+<% end %>
+
+<%= simple_form_for @show_note, url: dashboard_playlist_video_show_note_path(video_id: @video.slug, playlist_id: @playlist.slug) do |f| %>
+  <%= f.input :language, collection: [['es', 'es']], include_blank: false %>
+  <%= f.input :content, input_html: { rows: 10 } %>
+  <%= f.submit class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/dashboard/videos/show.html.erb
+++ b/app/views/dashboard/videos/show.html.erb
@@ -48,7 +48,7 @@
       <%= link_to t('.edit'), dashboard_playlist_video_show_note_path(video_id: @video.slug, playlist_id: @video.playlist.slug), class: 'btn btn-default' %>
       <br>
       <% if @video.show_note.present? %>
-      <%= button_to t('.destroy'), [:dashboard, @playlist, @video, :transcription], method: :delete, class: 'btn btn-danger', data: { confirm: '¿De verdad?' } %>
+      <%= button_to t('.destroy'), [:dashboard, @playlist, @video, :show_note], method: :delete, class: 'btn btn-danger', data: { confirm: '¿De verdad?' } %>
       <% end %>
     </td>
     <td>

--- a/app/views/dashboard/videos/show.html.erb
+++ b/app/views/dashboard/videos/show.html.erb
@@ -43,6 +43,20 @@
   </tr>
   <tr>
     <td>
+      <%= t('.show_notes') %>
+      <br>
+      <%= link_to t('.edit'), dashboard_playlist_video_show_note_path(video_id: @video.slug, playlist_id: @video.playlist.slug), class: 'btn btn-default' %>
+      <br>
+      <% if @video.show_note.present? %>
+      <%= button_to t('.destroy'), [:dashboard, @playlist, @video, :transcription], method: :delete, class: 'btn btn-danger', data: { confirm: '¿De verdad?' } %>
+      <% end %>
+    </td>
+    <td>
+      <%= @video.show_note.present? ? to_markdown(@video.show_note.content).html_safe : t('.no_show_notes') %>
+    </td>
+  </tr>
+  <tr>
+    <td>
       <%= t('.transcription') %>
       <br>
       <%= link_to t('.edit'), dashboard_playlist_video_transcription_path(video_id: @video.slug, playlist_id: @video.playlist.slug), class: 'btn btn-default' %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -89,9 +89,9 @@
           </ul>
         <% end %>
 
-        <% if @video.transcription.present? %>
-          <h3><%= t('.transcription') %></h3>
-          <%= to_markdown(@video.transcription.content).html_safe %>
+        <% if @video.show_note.present? %>
+          <h3><%= t('.show_notes') %></h3>
+          <%= to_markdown(@video.show_note.content).html_safe %>
         <% end %>
 
         <p>
@@ -99,11 +99,11 @@
           <%= t('.duration', duration: running_time(@video.duration)) %>
         </p>
 
-        <%= render(partial: 'cards') unless @video.transcription.present? %>
+        <%= render(partial: 'cards') unless @video.show_note.present? %>
       </div>
 
       <div class="col-md-5">
-        <%= render(partial: 'cards') if @video.transcription.present? %>
+        <%= render(partial: 'cards') if @video.show_note.present? %>
         <div class="discord-cta">
           <%= link_to '/discord' do %>
             <p class="lead">👉 ¿Algo no quedó claro?</p>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -78,7 +78,7 @@
 <div class="row">
 
       <div class="col-md-7">
-        <p><%= to_markdown(@video.description).html_safe %></p>
+        <p><strong><%= to_markdown(@video.description).html_safe %></strong></p>
 
         <% unless @video.links.empty? %>
           <p><%= t('.links') %>:</p>

--- a/config/locales/dashboard.es.yml
+++ b/config/locales/dashboard.es.yml
@@ -269,6 +269,8 @@ es:
         published_at: Fecha de publicación
         playlist: Lista
         really_destroy: Eliminar un vídeo no tiene vuelta atrás. Una vez eliminado, todos sus datos serán borrados y habrá que volver a crearlo de nuevo.
+        show_notes: Notas del episodio
+        no_show_notes: (Este episodio no tiene notas)
         transcription: Transcripción
         no_transcription: (Transcripción no existente)
         seconds:
@@ -285,6 +287,11 @@ es:
       show:
         dashboard: Panel de control
         transcription: Transcripción
+        cancel: Cancelar
+    show_notes:
+      show:
+        dashboard: Panel de control
+        show_notes: Notas de episodio
         cancel: Cancelar
   layouts:
     dashboard:

--- a/config/locales/dashboard.es.yml
+++ b/config/locales/dashboard.es.yml
@@ -270,7 +270,7 @@ es:
         playlist: Lista
         really_destroy: Eliminar un vídeo no tiene vuelta atrás. Una vez eliminado, todos sus datos serán borrados y habrá que volver a crearlo de nuevo.
         show_notes: Notas del episodio
-        no_show_notes: (Este episodio no tiene notas)
+        no_show_notes: (No existen notas del episodio)
         transcription: Transcripción
         no_transcription: (Transcripción no existente)
         seconds:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -154,6 +154,7 @@ es:
         other: Una lista de reproducción de %{count} episodios.
     show:
       transcription: Transcripción
+      show_notes: Notas del episodio
       next: Siguiente
       part_of_series_html: "Un episodio de %{playlist}"
       previous: Anterior

--- a/config/locales/model.es.yml
+++ b/config/locales/model.es.yml
@@ -9,6 +9,7 @@ es:
       transcription:
         one: Transcripción
         other: Transcripciones
+      show_note: Notas del episodio
       opinion:
         one: Opinión
         other: Opiniones
@@ -35,6 +36,9 @@ es:
         slug: URL
         title: Título
       transcription:
+        language: Idioma
+        content: Contenido
+      show_note:
         language: Idioma
         content: Contenido
       user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         resources :videos, except: %i[index new create] do
           resources :links
           resource :transcription, only: %i[show create update destroy]
+          resource :show_note, only: %i[show create update destroy]
           put :move, on: :member
         end
       end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -12,4 +12,10 @@ FactoryBot.define do
     language { 'es' }
     content { 'This is the transcription of a video' }
   end
+
+  factory :show_note do
+    documentable { build(:video) }
+    language { 'es' }
+    content { 'These are the shownotes of a video' }
+  end
 end

--- a/spec/features/dashboard/show_notes_spec.rb
+++ b/spec/features/dashboard/show_notes_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Dashboard show notes', type: :feature, js: true do
           click_link 'Editar'
         end
         fill_in 'Contenido', with: 'Estas son mis notas de episodio'
-        click_button 'Crear Notas de episodio'
+        click_button 'Crear Notas del episodio'
         within(:xpath, row) do
           expect(page).to have_text 'Estas son mis notas de episodio'
         end
@@ -78,9 +78,9 @@ RSpec.describe 'Dashboard show notes', type: :feature, js: true do
           click_link 'Editar'
         end
         fill_in 'Contenido', with: 'Estas son las nuevas notas de episodio'
-        click_button 'Actualizar Transcripción'
+        click_button 'Actualizar Notas del episodio'
         within(:xpath, row) do
-          expect(page).to have_text 'Estas son mis notas de episodio'
+          expect(page).to have_text 'Estas son las nuevas notas de episodio'
         end
       end
 

--- a/spec/features/dashboard/show_notes_spec.rb
+++ b/spec/features/dashboard/show_notes_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Dashboard show notes', type: :feature, js: true do
+  let(:user) { create(:user) }
+  let(:playlist) { create(:playlist) }
+  let(:video) { create(:video, playlist: playlist) }
+
+  let(:row) { "//tr[./td//text()[contains(., 'Notas del episodio')]]" }
+
+  before do
+    Capybara.app_host = 'http://dashboard.lvh.me:9080'
+    Capybara.server_port = 9080
+  end
+
+  after do
+    Capybara.app_host = nil
+    Capybara.server_port = nil
+  end
+
+  describe 'for anonymous sessions' do
+    let(:path) { dashboard_playlist_video_show_note_path(video, playlist_id: playlist.slug) }
+
+    it 'is not possible to visit the show notes editor' do
+      visit path
+      expect(page).to have_no_current_path path
+    end
+  end
+
+  describe 'for logged in sessions' do
+    before { login_as user, scope: :user }
+
+    describe 'when there is no show notes present for a video' do
+      it 'says so if I visit the video page' do
+        visit dashboard_playlist_video_path(video, playlist_id: playlist.slug)
+        within(:xpath, row) do
+          expect(page).to have_text '(No existen notas del episodio)'
+        end
+      end
+
+      it 'will allow me to create some show notes' do
+        visit dashboard_playlist_video_path(video, playlist_id: playlist.slug)
+        within(:xpath, row) do
+          click_link 'Editar'
+        end
+        fill_in 'Contenido', with: 'Estas son mis notas de episodio'
+        click_button 'Crear Notas de episodio'
+        within(:xpath, row) do
+          expect(page).to have_text 'Estas son mis notas de episodio'
+        end
+      end
+
+      it 'will not allow me to delete some show notes' do
+        visit dashboard_playlist_video_path(video, playlist_id: playlist.slug)
+        within(:xpath, row) do
+          expect(page).not_to have_link 'Destruir'
+        end
+      end
+    end
+
+    describe 'when there is some show notes present for a video' do
+      before do
+        create(:show_note, documentable: video,
+                           content: 'Estas son mis notas de episodio')
+      end
+
+      it 'presents the show notes in the video page' do
+        visit dashboard_playlist_video_path(video, playlist_id: playlist.slug)
+        within(:xpath, row) do
+          expect(page).to have_text 'Estas son mis notas de episodio'
+        end
+      end
+
+      it 'will allow me to edit some show notes' do
+        visit dashboard_playlist_video_path(video, playlist_id: playlist.slug)
+        within(:xpath, row) do
+          click_link 'Editar'
+        end
+        fill_in 'Contenido', with: 'Estas son las nuevas notas de episodio'
+        click_button 'Actualizar Transcripción'
+        within(:xpath, row) do
+          expect(page).to have_text 'Estas son mis notas de episodio'
+        end
+      end
+
+      it 'allows me to delete some show notes' do
+        visit dashboard_playlist_video_path(video, playlist_id: playlist.slug)
+        within(:xpath, row) do
+          page.accept_confirm do
+            click_button 'Destruir'
+          end
+        end
+
+        within(:xpath, row) do
+          expect(page).to have_text '(No existen notas del episodio)'
+        end
+      end
+    end
+  end
+end

--- a/spec/features/videos/video_page_spec.rb
+++ b/spec/features/videos/video_page_spec.rb
@@ -55,17 +55,17 @@ RSpec.describe 'Video page', type: :feature do
     end
   end
 
-  describe 'when the video has a transcription' do
+  describe 'when the video has show notes' do
     let(:topic) { create(:topic) }
     let(:playlist) { create(:playlist, topic: topic) }
-    let(:transcription) { build(:transcription, documentable: nil) }
-    let(:video) { create(:video, playlist: playlist, transcription: transcription) }
+    let(:show_note) { build(:show_note, documentable: nil) }
+    let(:video) { create(:video, playlist: playlist, show_note: show_note) }
 
-    it 'presents the transcription' do
+    it 'presents the show notes' do
       visit_video video
 
       within("//div[@class='video-information']") do
-        expect(page).to have_content transcription.content
+        expect(page).to have_content show_note.content
       end
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -30,4 +30,10 @@ RSpec.describe Document, type: :model do
       expect(build(:transcription).type).to eq('Transcription')
     end
   end
+
+  describe 'show note' do
+    it 'is a type of document' do
+      expect(build(:show_note).type).to eq('ShowNote')
+    end
+  end
 end


### PR DESCRIPTION
Instead of presenting transcriptions, there will be a differentiation
between transcriptions and show notes.

-   Transcription is a full text representations of the spoken words in
    the video. This is useful for search purposes because it offers a
    way to search for words, but most of the time the transcription will
    not be clean and contain sentences that make no sense when read
    along.
-   Show notes is similar to an article associated to a video,
    containing a clean representation of whatever is being made in the
    video, formatted with pretty format and using paragraphs at
    appropiate positions.

This commit will keep the transcription data model and support for
adding and deleting transcriptions, but it will add a separate editor
for show notes, and will change the front-end so that the transcriptions
is not visible: the show notes will be visible instead.
