### PR TITLE
fix(ci): pin meilisearch to 0.23

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       meilisearch:
-        image: getmeili/meilisearch
+        image: getmeili/meilisearch:v0.23.1
         env:
           MEILI_MASTER_KEY: meilikey
         ports:


### PR DESCRIPTION
meilisearch updated to 0.24 with breaking changes.

Until I update meilisearch-ruby and meilisearch-rails to use the newer API, I must pin the 0.23, or the tests and production environment will fail because the API has changed.