### PR TITLE
chore(ops): better CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,11 +1,15 @@
-name: Build and Deploy Docker image
+name: CD
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
     branches:
       - trunk
+    types:
+      - completed
 jobs:
   docker:
-    name: Release Docker images
+    name: Build Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +29,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
   deploy:
-    name: Deploy into my server
+    name: Deploy into makigas.es
     needs: [docker]
     runs-on: ubuntu-latest
     environment: public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   rspec:
-    name: Run rspec
+    name: RSpec
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -57,7 +57,7 @@ jobs:
           MEILISEARCH_HOST: http://localhost:7700
           MEILISEARCH_API_KEY: meilikey
   rubocop:
-    name: Run rubocop
+    name: Rubocop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -70,3 +70,17 @@ jobs:
           bundler-cache: true
       - name: Run Rubocop
         run: bundle exec rubocop
+  assets:
+    name: Asset precompile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install libpq-dev
+        run: sudo apt-get -yqq install libpq-dev
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0.2'
+          bundler-cache: true
+      - name: Build assets
+        run: bundle exec rails assets:precompile

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@rails/webpacker": "5.4.3",
     "bootstrap": "^3.4.0",
     "cookieconsent": "^3.1.0",
-    "jquery": "^3.6.0"
+    "jquery": "^3.6.0",
+    "normalize.css": "^8.0.1"
   },
   "devDependencies": {
     "@storybook/addon-controls": "^6.3.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6628,6 +6628,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+normalize.css@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
+  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
+
 npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"


### PR DESCRIPTION
After another failing pipeline, clearly I need a better CI/CD pipeline.

Proposed changes:

* Rename Ruby to CI, so that I can feel more comfortable writing CI
  pipelines that test something that is not Ruby (ESLint, Stylelint...).
* Rename Docker to CD; it is the most logical step after renaming Ruby
  to CI.
* Only start CD when CI successfully ends.
* Build assets on CI step.

Fixes asset pipeline build stage by installing normalize.css.