### PR TITLE
ops: switch to delayed-job for indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,11 @@ gem 'rails-i18n', '~> 6.0.0'
 gem 'sass-rails', '~> 6.0'
 gem 'uglifier', '>= 1.3.0'
 
+# Job processing
+gem 'delayed_job'
+gem 'delayed_job_active_record'
+gem 'delayed_job_web'
+
 # Application extras
 gem 'acts_as_list'
 gem 'aws-sdk-s3', '~> 1.113.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,16 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    delayed_job (4.1.10)
+      activesupport (>= 3.0, < 8.0)
+    delayed_job_active_record (4.1.7)
+      activerecord (>= 3.0, < 8.0)
+      delayed_job (>= 3.0, < 5)
+    delayed_job_web (1.4.4)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      rack-protection (>= 1.5.5)
+      sinatra (>= 1.4.4)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -237,6 +247,8 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.5)
     multi_xml (0.6.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     nenv (0.3.0)
     nio4r (2.5.8)
     nokogiri (1.13.3)
@@ -260,6 +272,8 @@ GEM
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-protection (2.2.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.4.7)
@@ -378,6 +392,11 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
+    sinatra (2.2.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.2.0)
+      tilt (~> 2.0)
     sitemap_generator (6.2.1)
       builder (~> 3.0)
     sprockets (4.0.3)
@@ -437,6 +456,9 @@ DEPENDENCIES
   byebug
   capybara (~> 3.36.0)
   chroma
+  delayed_job
+  delayed_job_active_record
+  delayed_job_web
   devise
   dotenv-rails
   factory_bot (~> 6.2.0)

--- a/app/models/show_note.rb
+++ b/app/models/show_note.rb
@@ -5,6 +5,6 @@ class ShowNote < Document
   after_save :index_documentable
 
   def index_documentable
-    documentable.index! if documentable.respond_to?(:index)
+    documentable.save
   end
 end

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Transcription < Document
-  after_destroy :index_documentable
-  after_save :index_documentable
+  after_destroy :touch_documentable
+  after_save :touch_documentable
 
-  def index_documentable
-    documentable.index! if documentable.respond_to?(:index!)
+  def touch_documentable
+    documentable.save
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -4,7 +4,7 @@ class Video < ApplicationRecord
   extend FriendlyId
 
   include MeiliSearch::Rails
-  meilisearch per_environment: true, raise_on_failure: Rails.env.development? do
+  meilisearch enqueue: true, per_environment: true, raise_on_failure: Rails.env.development? do
     attribute :title, :description
 
     attribute(:transcription) { transcription&.content }

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,8 @@ module Makigas
 
     # Configure exceptions to show our custom /404 and /500 pages.
     config.exceptions_app = routes
+
+    # Configure Delayed Job
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,4 +56,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Use a test adapter for running jobs
+  config.active_job.queue_adapter = :test
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,4 +58,6 @@ Rails.application.routes.draw do
   get '/videos/:playlist' => redirect('/series/%{playlist}')
 
   mount Lookbook::Engine, at: '/lookbook'
+
+  match '/delayed_job' => DelayedJobWeb, :anchor => false, :via => %i[get post]
 end

--- a/db/migrate/20220223221207_create_delayed_jobs.rb
+++ b/db/migrate/20220223221207_create_delayed_jobs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateDelayedJobs < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :delayed_jobs do |table|
+      table.integer :priority, default: 0, null: false
+      table.integer :attempts, default: 0, null: false
+      table.text :handler, null: false
+      table.text :last_error
+      table.datetime :run_at
+      table.datetime :locked_at
+      table.datetime :failed_at
+      table.string :locked_by
+      table.string :queue
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, %i[priority run_at], name: 'delayed_jobs_priority'
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_12_135028) do
+ActiveRecord::Schema.define(version: 2022_02_23_221207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,21 @@ ActiveRecord::Schema.define(version: 2021_10_12_135028) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "documents", force: :cascade do |t|

--- a/spec/features/videos/videos_search_spec.rb
+++ b/spec/features/videos/videos_search_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe 'Videos search', type: :feature do
     let!(:medium) { create(:video, duration: 600, title: 'Medium', youtube_id: '2') }
     let!(:long) { create(:video, duration: 1200, title: 'Long', youtube_id: '3') }
 
-    after { Video.clear_index! }
-
     it 'can search for short length videos' do
       # Tune the search service mock for this purpose.
       inst = instance_double('VideoSearch', videos: Video.where('duration < 300').page(1).per(10))

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -29,11 +29,39 @@ RSpec.describe Document, type: :model do
     it 'is a type of document' do
       expect(build(:transcription).type).to eq('Transcription')
     end
+
+    describe 'indexing' do
+      let(:video) { create(:video) }
+
+      it 'happens after saving' do
+        document = build(:transcription, documentable: video)
+        expect { document.save }.to have_enqueued_job(MeiliSearch::Rails::MSJob).with(video, 'ms_index!')
+      end
+
+      it 'happens after deletion' do
+        document = create(:transcription, documentable: video)
+        expect { document.destroy }.to have_enqueued_job(MeiliSearch::Rails::MSJob).with(video, 'ms_index!')
+      end
+    end
   end
 
   describe 'show note' do
     it 'is a type of document' do
       expect(build(:show_note).type).to eq('ShowNote')
+    end
+
+    describe 'indexing' do
+      let(:video) { create(:video) }
+
+      it 'happens after saving' do
+        document = build(:show_note, documentable: video)
+        expect { document.save }.to have_enqueued_job(MeiliSearch::Rails::MSJob).with(video, 'ms_index!')
+      end
+
+      it 'happens after deletion' do
+        document = create(:show_note, documentable: video)
+        expect { document.destroy }.to have_enqueued_job(MeiliSearch::Rails::MSJob).with(video, 'ms_index!')
+      end
     end
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -201,4 +201,19 @@ RSpec.describe Video, type: :model do
       expect(described_class.tags).to match_array %w[python git ruby]
     end
   end
+
+  describe 'indexing' do
+    it 'happens after saving' do
+      video = build(:video)
+      expect { video.save }.to have_enqueued_job(MeiliSearch::Rails::MSJob).with(video, 'ms_index!')
+    end
+
+    it 'happens after deletion' do
+      video = create(:video)
+      gid_descriptor = { '_aj_globalid' => video.to_gid.to_s }
+      expect do
+        video.destroy
+      end.to have_enqueued_job(MeiliSearch::Rails::MSJob).with(gid_descriptor, 'ms_remove_from_index!')
+    end
+  end
 end


### PR DESCRIPTION
Instead of indexing in the main application, which always requires MeiliSearch to be running and it is cumbersome to do in development and testing mode, defer indexing to a worker.