### PR TITLE
fix(searchbar): moz placeholder color

### DIFF
--- a/app/javascript/six/components/navbar.scss
+++ b/app/javascript/six/components/navbar.scss
@@ -128,6 +128,7 @@ $navbar-size: 40px;
 
     &__search::placeholder {
       color: rgb(70 70 70 / 90%);
+      opacity: 1; /* firefox workaround (see #712) */
     }
   }
 


### PR DESCRIPTION
Well, turns out Mozilla Firefox's placeholders have a less than 100% opacity. Not sure of the real value, but we want the placeholder color to be consistent across browsers.