### PR TITLE
feat: add hierarchical topic relationships

### DIFF
--- a/app/components/six/layout/navbar_explorer_component.rb
+++ b/app/components/six/layout/navbar_explorer_component.rb
@@ -4,7 +4,7 @@ module Six
   module Layout
     class NavbarExplorerComponent < ViewComponent::Base
       def topics
-        Topic.all
+        Topic.where(parent_topic_id: nil)
       end
     end
   end

--- a/app/controllers/dashboard/topics_controller.rb
+++ b/app/controllers/dashboard/topics_controller.rb
@@ -41,7 +41,7 @@ module Dashboard
     private
 
     def topic_params
-      params.require(:topic).permit(:title, :description, :color, :thumbnail)
+      params.require(:topic).permit(:title, :description, :color, :thumbnail, :parent_topic_id)
     end
 
     def topic_set

--- a/app/views/dashboard/topics/_form.html.erb
+++ b/app/views/dashboard/topics/_form.html.erb
@@ -6,6 +6,7 @@
       <%= form.color_field :color %>
     </p>
   <% end %>
+  <%= form.association :parent_topic, include_blank: :translate %>
   <%= form.input :thumbnail, as: :file %>
   <%= form.submit class: 'btn btn-success' %>
 <% end %>

--- a/app/views/dashboard/topics/show.html.erb
+++ b/app/views/dashboard/topics/show.html.erb
@@ -24,6 +24,10 @@
     <td><%= image_tag @topic.thumbnail.url(:small) %></td>
   </tr>
   <tr>
+    <td><%= t('.parent_topic') %></td>
+    <td><%= @topic.parent_topic.try(:title) || t('.none') %></td>
+  </tr>
+  <tr>
     <td><%= t('.color') %></td>
     <td><%= content_tag(:span, @topic.color, class: 'label', style: "background-color: #{@topic.color}") %></td>
   </tr>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -30,4 +30,4 @@
 <% content_for(:hero) do %>
   <h1><%= @topic.title %></h1>
 <% end %>
-<%= render Six::Explorer::PlaylistListComponent.new(playlists: @topic.playlists.with_public_videos) %>
+<%= render Six::Explorer::PlaylistListComponent.new(playlists: @topic.playlists_with_children.with_public_videos) %>

--- a/config/locales/dashboard.es.yml
+++ b/config/locales/dashboard.es.yml
@@ -226,6 +226,8 @@ es:
         topics: Temas
         thumbnail: Miniatura
         view_topic: Ver Tema
+        parent_topic: Tema superior
+        none: (Ninguno)
       update:
         updated: Tema actualizado correctamente.
     users:

--- a/config/locales/model.es.yml
+++ b/config/locales/model.es.yml
@@ -36,6 +36,7 @@ es:
         thumbnail: Miniatura
         slug: URL
         title: Título
+        parent_topic: Tema superior
       transcription:
         language: Idioma
         content: Contenido
@@ -62,3 +63,5 @@ es:
     include_blanks:
       playlist:
         topic: (Sin tema concreto)
+      topic:
+        parent_topic: (Sin tema superior)

--- a/db/migrate/20230724160243_add_parent_id_to_topic.rb
+++ b/db/migrate/20230724160243_add_parent_id_to_topic.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddParentIdToTopic < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :topics, :parent_topic, nullable: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_18_101448) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_24_160243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -134,6 +134,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_18_101448) do
     t.bigint "thumbnail_file_size"
     t.datetime "thumbnail_updated_at"
     t.string "color"
+    t.bigint "parent_topic_id"
+    t.index ["parent_topic_id"], name: "index_topics_on_parent_topic_id"
     t.index ["slug"], name: "index_topics_on_slug", unique: true
   end
 

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -15,10 +15,12 @@
 #  title                  :string           not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  parent_topic_id        :bigint
 #
 # Indexes
 #
-#  index_topics_on_slug  (slug) UNIQUE
+#  index_topics_on_parent_topic_id  (parent_topic_id)
+#  index_topics_on_slug             (slug) UNIQUE
 #
 FactoryBot.define do
   factory :topic do

--- a/spec/features/topics/topic_page_spec.rb
+++ b/spec/features/topics/topic_page_spec.rb
@@ -23,6 +23,29 @@ RSpec.describe 'Topic page' do
     end
   end
 
+  context 'when the topic has child topics' do
+    let(:child_playlist) { create(:playlist).tap { |p| create(:video, playlist: p) } }
+    let(:child_topic) { create(:topic, playlists: [child_playlist]) }
+    let(:parent_playlist) { create(:playlist).tap { |p| create(:video, playlist: p) } }
+    let(:parent_topic) { create(:topic, playlists: [parent_playlist], child_topics: [child_topic]) }
+
+    it 'includes the child playlists in the parent page' do
+      visit topic_path(parent_topic)
+      aggregate_failures do
+        expect(page).to have_text parent_playlist.title
+        expect(page).to have_text child_playlist.title
+      end
+    end
+
+    it 'does not not include the parent playlists in the child page' do
+      visit topic_path(child_topic)
+      aggregate_failures do
+        expect(page).not_to have_text parent_playlist.title
+        expect(page).to have_text child_playlist.title
+      end
+    end
+  end
+
   context 'when the playlist is empty' do
     let(:playlist) { create(:playlist, videos: []) }
     let(:topic) { create(:topic, playlists: [playlist]) }


### PR DESCRIPTION
Topics now may belong to other topics. Therefore, a topic can be considered a child of another topic. Parent topics will include links to the playlists of the playlist topics when visiting their page, so visiting the topic page for Java will include the playlist for any other topic whose parent_topic_id is set to the Java topic ID.