### PR TITLE
makigas 7.0

### DIFF
--- a/app/javascript/packs/seven.js
+++ b/app/javascript/packs/seven.js
@@ -1,0 +1,9 @@
+/**
+ * makigas 7.0
+ */
+
+import "normalize.css";
+import "@fontsource/montserrat/400.css";
+import "@fontsource/montserrat/700.css";
+
+import "@makigas/genshi/dist/genshi.css";

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -17,8 +17,8 @@
 <%= content_for(:meta) if content_for?(:meta) -%>
 <%= content_for(:twitter) -%>
 <%= content_for(:facebook) -%>
-<%= stylesheet_link_tag 'six', media: 'all' %>
-<%= javascript_include_tag 'six', defer: true %>
+<%= stylesheet_link_tag 'seven', media: 'all' %>
+<%= javascript_include_tag 'seven', defer: true %>
 <link rel="apple-touch-icon" href="/icons/color/makigas-192.png">
 <link rel="icon" href="/icons/makigas-auto.svg" type="image/svg+xml">
 <link rel="icon" href="/icons/color/makigas-64.png" type="image/png">

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,4 +1,4 @@
-<%= stylesheet_link_tag 'six', media: :all %>
+<%= stylesheet_link_tag 'seven', media: :all %>
 
 <div style="max-width: <%= params[:lookbook][:display][:max_width] || '100%' %>; padding: <%= params[:lookbook][:display][:padding] || '0' %>; background-color: <%= params[:lookbook][:display][:bgcolor] || 'transparent' %>">
       <% if params[:lookbook][:display][:wrapper] == true %>
@@ -8,4 +8,4 @@
       <% end %>
     </div>
 
-<%= javascript_include_tag 'six' %>
+<%= javascript_include_tag 'seven' %>

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -3,7 +3,7 @@ import postcss from "esbuild-postcss";
 import Watcher from "watcher";
 
 const options = {
-  entryPoints: ["app/javascript/packs/dashboard.js", "app/javascript/packs/six.js"],
+  entryPoints: ["app/javascript/packs/dashboard.js", "app/javascript/packs/six.js", "app/javascript/packs/seven.js"],
   bundle: true,
   logLevel: "info",
   outdir: "app/assets/builds",


### PR DESCRIPTION
# Scope

makigas 7.0 updates the stylesheet and fixes some bad practices introduced in makigas 6.0.
This is not exactly a redesign of the website, because the logical structure of the site will remain the same. It only changes the stylesheet and cleanups the components.

Visible goals for users:
* makigas.es will support dark mode finally.
* After makigas 7.0, new sections will be easier to add.

Internal goals:
* The stylesheet makes use of relative units such as `rem`, rather than hardcoding pixels everywhere.
* There is support for forms. They will come handy for replacing the old dashboard with the new CMS.
* The components are refactored to make them easy to manage (for instance, helper methods like `makigas_whatever(**opts)` rather than a lot of `render Six::Base::Whatver::WhateverComponent.new(**opts)`.

Non goals:
* Add new sections or replace the site layout (but there will be time for that, don't worry...)

# Stack

Mostly the same. Maybe I remove some PostCSS plugins and add a few of them. I'll continue using esbuild in the time being, but given that Rails 8.0 added a new asset manager (once again), maybe it's time to evaluate compatibility with other tools.

makigas.es will use [Genshi](https://github.com/makigas/genshi) – as expected, because Genshi is the core of the makigas.es stylesheet.